### PR TITLE
Fix auto-save interval and action toggle

### DIFF
--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -256,7 +256,7 @@ function makeActionUnavailable(actionId) {
 
 function toggleAction(actionId) {
   const index = gameState.actionsActive.indexOf(actionId);
-  if (index === 0) {
+  if (index !== -1) {
     deactivateAction(actionId);
   } else {
     activateAction(actionId);

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -48,5 +48,5 @@ let lastUpdateTime = Date.now();
 
 //openTab('actions-tab');
 window.requestAnimationFrame(updateFrameClock);
-window.onload = loadGame();
-setInterval(saveGame(), 10000);
+window.onload = loadGame;
+setInterval(saveGame, 10000);


### PR DESCRIPTION
## Summary
- Correct timer setup so game saves periodically instead of once
- Fix action toggling logic to properly deactivate any active action

## Testing
- `node --check assets/scripts/start.js`
- `node --check assets/scripts/action_functions.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68958fe66b54832482efc61057c7902e