### PR TITLE
Add reset popup with stat summary and manual restart

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -76,6 +76,26 @@ body {
   margin-right: 1.5rem;
 }
 
+#reset-popup {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+  #reset-popup .reset-content {
+    background: #fff;
+    padding: 20px;
+    border-radius: 10px;
+    max-width: 300px;
+  }
+
 /* MENU */
   .menu-button {
     width:auto;

--- a/index.html
+++ b/index.html
@@ -15,6 +15,13 @@
     <div class="row">
       <div class="container m-0 game-wrapper p-3">
         <div id="popup-container"></div>
+        <div id="reset-popup" class="d-none">
+          <div class="reset-content text-center">
+            <h3>Run Over</h3>
+            <ul id="reset-summary" class="text-start"></ul>
+            <button class="menu-button" onclick="restartGame()">Restart</button>
+          </div>
+        </div>
 
         <!-- Row for menu buttons -->
         <div class="row px-3">


### PR DESCRIPTION
## Summary
- Show game-over popup with stat changes and restart button
- Disable non-menu controls when health is depleted and pause the game
- Style overlay for reset popup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689593b98aa883248e1f8cbc508da8e1