### PR TITLE
Ensure event popups appear above progress bars

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -74,6 +74,7 @@ body {
   position: fixed;
   bottom: 1.5rem; left: 1.5rem;
   margin-right: 1.5rem;
+  z-index: 1000;
 }
 
 #reset-popup {


### PR DESCRIPTION
## Summary
- Add z-index to popup container so popups render over action progress bars

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895a2e1456c83249a684972073c439d