### PR TITLE
Allow starting actions by clicking the action body

### DIFF
--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -17,21 +17,29 @@ class GameAction {
 				}
 			});
 
-			this.container = document.getElementById(id);
-			this.elements = {
-				container: this.container,
-	      progressContainer: this.container.querySelector('.action-progress-container'),
-	      progressText: this.container.querySelector('.action-progress-text'),
-	      progressBarCurrent: this.container.querySelector('.action-progress-bar-current'),
-	      progressBarMastery: this.container.querySelector('.action-progress-bar-mastery'),
-	      buttonActivate: this.container.querySelector('.action-button'),
-	      buttonQueue: this.container.querySelector('.queue-button'),
-	      queueList: this.container.querySelector('.queue-list')
-			}
+                        this.container = document.getElementById(id);
+                        this.elements = {
+                                container: this.container,
+              progressContainer: this.container.querySelector('.action-progress-container'),
+              progressText: this.container.querySelector('.action-progress-text'),
+              progressBarCurrent: this.container.querySelector('.action-progress-bar-current'),
+              progressBarMastery: this.container.querySelector('.action-progress-bar-mastery'),
+              buttonActivate: this.container.querySelector('.action-button'),
+              buttonQueue: this.container.querySelector('.queue-button'),
+              queueList: this.container.querySelector('.queue-list')
+                        }
+      // Allow clicking anywhere on the action body to toggle the action
+      this.container.addEventListener('click', () => toggleAction(id));
 
       // Add button effects
-      this.elements.buttonActivate.addEventListener('click', () => toggleAction(id));
-      this.elements.buttonQueue.addEventListener('click', () => queueAction(id));
+      this.elements.buttonActivate.addEventListener('click', (event) => {
+        event.stopPropagation();
+        toggleAction(id);
+      });
+      this.elements.buttonQueue.addEventListener('click', (event) => {
+        event.stopPropagation();
+        queueAction(id);
+      });
 
       this.calculateTimeStart();
       this.update();

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -235,6 +235,7 @@ body {
       border-radius: 10px;
       font-size: 0.8em;
       gap: 2px;
+      cursor: pointer;
     }
 
       .action-header {


### PR DESCRIPTION
## Summary
- Allow clicking anywhere on an action container to toggle the action
- Prevent start and queue buttons from triggering the container click handler
- Add pointer cursor to actions to indicate clickability

## Testing
- `node --check assets/scripts/action_functions.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895a2fa8eb0832489fa6cad866ef52c