### PR TITLE
Add artifact system that unlocks skills menu after first death

### DIFF
--- a/assets/scripts/action_effects.js
+++ b/assets/scripts/action_effects.js
@@ -1,5 +1,12 @@
 const skillList = ["courage", "creativity", "curiosity", "integrity", "perseverance", "resourcefulness"];
 
+const artifactData = {
+  skillbook: {
+    label: "Ancient Skillbook",
+    description: "Reveals the skills menu."
+  }
+};
+
 const default_action = {
   label: "Default Action Name",
   length: 5000,

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -111,6 +111,57 @@ function generateUniqueId() {
 let startingPermanentLevels = {};
 let gameOver = false;
 
+function updateArtifactsUI() {
+  const container = document.getElementById('artifact-list');
+  if (!container) {return;}
+  container.innerHTML = '';
+  const unlocked = Object.keys(gameState.artifacts || {}).filter(id => gameState.artifacts[id]);
+  if (unlocked.length === 0) {
+    const div = document.createElement('div');
+    div.textContent = 'No artifacts discovered yet.';
+    container.appendChild(div);
+    return;
+  }
+  unlocked.forEach(id => {
+    const art = artifactData[id];
+    if (!art) {return;}
+    const div = document.createElement('div');
+    div.className = 'artifact-container';
+    const name = document.createElement('div');
+    name.className = 'artifact-name';
+    name.textContent = art.label;
+    const desc = document.createElement('div');
+    desc.className = 'artifact-description';
+    desc.textContent = art.description;
+    div.appendChild(name);
+    div.appendChild(desc);
+    container.appendChild(div);
+  });
+}
+
+function applyArtifactEffects(id) {
+  if (id === 'skillbook') {
+    const skillsTab = document.getElementById('skills-tab');
+    if (skillsTab) {
+      skillsTab.classList.add('d-md-block');
+      skillsTab.classList.remove('d-none');
+    }
+    const skillsButton = document.getElementById('skills-button');
+    if (skillsButton) {skillsButton.classList.remove('d-none');}
+  }
+}
+
+function unlockArtifact(id) {
+  if (!artifactData.hasOwnProperty(id)) {return;}
+  if (!gameState.artifacts[id]) {
+    gameState.artifacts[id] = true;
+    updateArtifactsUI();
+    applyArtifactEffects(id);
+    logPopupCombo('You discovered ' + artifactData[id].label + '!', 'primary');
+    saveGame();
+  }
+}
+
 function recordStartingPermanentLevels() {
   startingPermanentLevels = {};
   skillList.forEach(skill => {
@@ -394,6 +445,7 @@ function showResetPopup(){
   });
 
   document.getElementById('reset-popup').classList.remove('d-none');
+  if (!gameState.artifacts.skillbook) {unlockArtifact('skillbook');}
 }
 
 function restartGame(){
@@ -438,6 +490,11 @@ function resetGameState() {
     removeAction(action);
   })
   actionsConstructed = {};
+
+  const skillsTab = document.getElementById('skills-tab');
+  if (skillsTab) {skillsTab.classList.add('d-none'); skillsTab.classList.remove('d-md-block');}
+  const skillsButton = document.getElementById('skills-button');
+  if (skillsButton) {skillsButton.classList.add('d-none');}
 
   initializeGame();
 }
@@ -510,4 +567,8 @@ function initializeGame() {
   updateSkill("perseverance", 0);
   updateSkill("resourcefulness", 0);
   recordStartingPermanentLevels();
+  Object.keys(gameState.artifacts).forEach(id => {
+    if (gameState.artifacts[id]) {applyArtifactEffects(id);}
+  });
+  updateArtifactsUI();
 }

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -17,6 +17,7 @@ const emptyGameState = {
   paused: pauseStates.NOT_PAUSED,
   gameLog: [],
   skills: {},
+  artifacts: {},
   globalParameters: {
     masteryMaxRatio: 0.9,
     masteryGrowthRate: 5e-6,

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -209,6 +209,22 @@ body {
           z-index: 1;
         }
 
+  /* ARTIFACTS */
+  .artifact-container {
+    background-color: rgba(255,255,255,0.6);
+    border-radius: 5px;
+    padding: 5px;
+    margin-bottom: 5px;
+  }
+
+    .artifact-name {
+      font-weight: bold;
+    }
+
+    .artifact-description {
+      font-size: 0.8em;
+    }
+
         .skill-current-bar {
           background-color: #000055;
         }

--- a/index.html
+++ b/index.html
@@ -48,8 +48,9 @@
           <div class="col">
             <span class="tab-button-container">
               <button class="tab-button" onClick="openTab('actions-tab')">A</button>
-              <button class="tab-button" onClick="openTab('skills-tab')">S</button>
+              <button id="skills-button" class="tab-button d-none" onClick="openTab('skills-tab')">S</button>
               <button class="tab-button" onClick="openTab('log-tab')">L</button>
+              <button class="tab-button" onClick="openTab('artifacts-tab')">R</button>
             </span>
           </div>
         </div>
@@ -60,7 +61,7 @@
           <!-- Main View. On by default. -->
           <div id="main-pane" class="content-pane col-12 full-height flex-vert">
             <!-- Skills -->
-            <div id="skills-tab" class="mobile-tab row d-none d-md-block">
+            <div id="skills-tab" class="mobile-tab row d-none">
               <div class="col all-skills-container">
                 <!-- Courage -->
                 <div id="courage" class="skill-container">
@@ -135,6 +136,10 @@
                   </div>
                 </div>
               </div>
+            </div>
+            <!-- Artifacts -->
+            <div id="artifacts-tab" class="mobile-tab row d-none d-md-block">
+              <div class="col" id="artifact-list"></div>
             </div>
             <!-- Actions and Game Log -->
             <div class="row row-col-1 row-col-md-2 row-fix">


### PR DESCRIPTION
## Summary
- Add persistent artifacts field and data, starting with an Ancient Skillbook
- Unlock first artifact upon death, revealing the skills menu
- Provide UI for viewing artifacts and hide skills until the Skillbook is obtained

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6895a8845d80832487baa6d2d7c4db74