### PR TITLE
Add global clock with time dilation and style retiming

### DIFF
--- a/assets/scripts/clock.js
+++ b/assets/scripts/clock.js
@@ -1,0 +1,88 @@
+function changeGlobalStyle(selector, property, value) {
+  for (let sheet of document.styleSheets) {
+    for (let rule of sheet.cssRules) {
+      if (rule.selectorText === selector) {
+        rule.style[property] = value;
+      }
+    }
+  }
+}
+
+class GlobalClock {
+  constructor() {
+    this.timer = null;
+    this.lastClockTime = performance.now();
+    this.accumulator = 0;
+    this.start();
+  }
+
+  start() {
+    if (this.timer) this.stop();
+    this.lastClockTime = performance.now();
+    const intervalMs = 1000 / gameState.globalParameters.renderHz;
+    this.timer = setInterval(() => this._beat(), intervalMs);
+  }
+
+  stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  _beat() {
+    const now = performance.now();
+    const clockDelta = now - this.lastClockTime; // real-world ms
+    this.lastClockTime = now;
+
+    const gameDelta = clockDelta * gameState.globalParameters.timeDilation;
+
+    // Emit events
+    document.dispatchEvent(new CustomEvent('heartbeat', { detail: { clockDelta } }));
+
+    // Fixed-step logic accumulator
+    const stepMs = 1000 / gameState.globalParameters.logicHz;
+    this.accumulator += gameDelta;
+    while (this.accumulator >= stepMs) {
+      document.dispatchEvent(new CustomEvent('tick-fixed', { detail: { stepMs } }));
+      this.accumulator -= stepMs;
+    }
+
+    // Variable-step game tick
+    document.dispatchEvent(new CustomEvent('tick', { detail: { gameDelta } }));
+
+    // Update clock in gameState
+    const paused = (typeof isGamePaused === 'function') ? isGamePaused() : false;
+    const c = gameState.clock;
+    c.totalClockTimeAll += clockDelta;
+    c.totalGameTimeAll += gameDelta;
+    c.totalClockTimeLoop += clockDelta;
+    c.totalGameTimeLoop += gameDelta;
+    if (!paused) {
+      c.unpausedClockTimeAll += clockDelta;
+      c.unpausedGameTimeAll += gameDelta;
+      c.unpausedClockTimeLoop += clockDelta;
+      c.unpausedGameTimeLoop += gameDelta;
+    }
+  }
+
+  setRenderHz(hz) {
+    gameState.globalParameters.renderHz = hz;
+    this.start();
+    changeGlobalStyle('.progress-bar', 'transition', `width ${Math.max(5, 1000 / hz)}ms linear`);
+  }
+
+  setLogicHz(hz) {
+    gameState.globalParameters.logicHz = hz;
+  }
+
+  setTimeDilation(multiplier) {
+    const clamped = Math.min(Math.max(multiplier, 0.05), 100);
+    gameState.globalParameters.timeDilation = clamped;
+    document.dispatchEvent(new CustomEvent('time-dilation-changed', { detail: { timeDilation: clamped } }));
+  }
+}
+
+window.addEventListener('load', () => {
+  window.gameClock = new GlobalClock();
+});

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -21,7 +21,20 @@ const emptyGameState = {
   globalParameters: {
     masteryMaxRatio: 0.9,
     masteryGrowthRate: 5e-6,
-    actionsMaxActive: 1
+    actionsMaxActive: 1,
+    renderHz: 60,
+    logicHz: 20,
+    timeDilation: 1
+  },
+  clock: {
+    totalClockTimeAll: 0,
+    totalGameTimeAll: 0,
+    totalClockTimeLoop: 0,
+    totalGameTimeLoop: 0,
+    unpausedClockTimeAll: 0,
+    unpausedGameTimeAll: 0,
+    unpausedClockTimeLoop: 0,
+    unpausedGameTimeLoop: 0
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -163,6 +163,7 @@
   <script src="./assets/scripts/action_functions.js"></script>
   <script src="./assets/scripts/action_effects.js"></script>
   <script src="./assets/scripts/script.js"></script>
+  <script src="./assets/scripts/clock.js"></script>
   <script src="./assets/scripts/start.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Introduce `GlobalClock` that tracks real-world and game time, dispatching heartbeat and tick events.
- Add clock settings and counters to the global game state.
- Include new script for global clock before `start.js` and retime progress bar transitions on render rate changes.

## Testing
- `node --check assets/scripts/clock.js`
- `node --check assets/scripts/start.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982b61019483249e91ea0ada5593e9