### PR TITLE
Add debug mode flag to default game state

### DIFF
--- a/assets/scripts/initialize.js
+++ b/assets/scripts/initialize.js
@@ -5,6 +5,7 @@ const pauseStates = {
 };
 
 const emptyGameState = {
+  debugMode: false,
   actionsAvailable: ['book1_action1'],
   actionsActive: [],
   actionsQueued: [],

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -6,6 +6,7 @@ const pauseStates = {
 }
 
 const emptyGameState = {
+  debugMode: false,
   actionsAvailable: ["book1_action1"],
   actionsActive: [],
   actionsQueued: [],


### PR DESCRIPTION
## Summary
- add `debugMode` boolean to `emptyGameState` in `initialize.js`
- add `debugMode` boolean to `emptyGameState` in `start.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689830ca41b48324a29d5d0539554a34