### PR TITLE
Log heartbeat ticks in debug mode

### DIFF
--- a/assets/scripts/clock.js
+++ b/assets/scripts/clock.js
@@ -85,4 +85,7 @@ class GlobalClock {
 
 window.addEventListener('load', () => {
   window.gameClock = new GlobalClock();
+  document.addEventListener('heartbeat', () => {
+    if (gameState.debugMode) console.log('Tick!');
+  });
 });


### PR DESCRIPTION
## Summary
- Add heartbeat listener after GlobalClock creation to log `Tick!` when `gameState.debugMode` is true

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689831e9c36c8324bb68e299c39cf54e