### PR TITLE
Add debug overlay for heartbeat metrics

### DIFF
--- a/assets/scripts/clock.js
+++ b/assets/scripts/clock.js
@@ -83,6 +83,26 @@ class GlobalClock {
   }
 }
 
+let totalTicks = 0;
+
+document.addEventListener('heartbeat', () => {
+  totalTicks += 1;
+  const overlay = document.getElementById('debug-overlay');
+  if (!overlay) return;
+
+  if (gameState.debugMode) {
+    const paused = (typeof isGamePaused === 'function') ? isGamePaused() : false;
+    overlay.style.display = 'block';
+    overlay.innerText =
+      `Render Hz: ${gameState.globalParameters.renderHz}\n` +
+      `Logic Hz: ${gameState.globalParameters.logicHz}\n` +
+      `Total Ticks: ${totalTicks}\n` +
+      `Paused: ${paused}`;
+  } else {
+    overlay.style.display = 'none';
+  }
+});
+
 window.addEventListener('load', () => {
   window.gameClock = new GlobalClock();
 });

--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
                   <div id="health-bar"></div>
               </div>
             </div>
+            <div id="debug-overlay" style="display:none;"></div>
           </div>
         </div>
         <!-- Tab row for mobile view -->


### PR DESCRIPTION
## Summary
- Add debug overlay container to HUD
- Update heartbeat listener to show render/logic rates, tick count, and pause state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689832088e7883248e569212ad0cf560