### PR TITLE
Standardize pause helpers with reason array

### DIFF
--- a/assets/scripts/pause_helpers.js
+++ b/assets/scripts/pause_helpers.js
@@ -1,0 +1,64 @@
+function addPauseState(state) {
+  if (!gameState.pausedReasons.includes(state)) {
+    gameState.pausedReasons.unshift(state);
+  }
+  processPauseButton();
+}
+
+function deletePauseState(state) {
+  if (state === undefined) {
+    gameState.pausedReasons = [];
+  } else {
+    gameState.pausedReasons = gameState.pausedReasons.filter(reason => reason !== state);
+  }
+  processPauseButton();
+}
+
+function isGamePaused() {
+  return gameState.pausedReasons.length > 0;
+}
+
+function processPauseButton(label) {
+  let text = '';
+  if (label !== undefined) {
+    text = label;
+  } else if (gameState.pausedReasons.includes(pauseStates.MANUAL)) {
+    text = pauseStates.MANUAL;
+  } else if (gameState.pausedReasons.includes(pauseStates.MODAL)) {
+    text = pauseStates.MODAL;
+  } else if (gameState.pausedReasons.includes(pauseStates.INACTIVE)) {
+    text = pauseStates.INACTIVE;
+  } else {
+    text = 'Running';
+  }
+  const el = document.getElementById('pause-button');
+  if (el) el.innerText = text;
+}
+
+// Backwards compatibility helpers
+function addPauseReason(state, _logText, label) {
+  addPauseState(state);
+  if (label !== undefined) {
+    processPauseButton(label);
+  }
+}
+
+function removePauseReason(state, _logText, label) {
+  deletePauseState(state);
+  if (label !== undefined) {
+    processPauseButton(label);
+  }
+}
+
+function clearPauseReasons() {
+  deletePauseState();
+}
+
+// Optional property shim for old `gameState.paused` checks
+window.addEventListener('load', () => {
+  if (typeof gameState === 'object' && !Object.getOwnPropertyDescriptor(gameState, 'paused')) {
+    Object.defineProperty(gameState, 'paused', {
+      get() { return isGamePaused(); }
+    });
+  }
+});

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -390,9 +390,9 @@ function updateFrameClock(currentTime) {
 
   // Auto pause when there are no actions, unpause when there are any
   if ((gameState.actionsActive.length + gameState.actionsQueued.length) === 0) {
-    addPauseReason(pauseStates.INACTIVE);
+    addPauseState(pauseStates.INACTIVE);
   } else {
-    removePauseReason(pauseStates.INACTIVE);
+    deletePauseState(pauseStates.INACTIVE);
   }
 
   if (currentTime === undefined) {
@@ -434,56 +434,10 @@ function updateFrameClock(currentTime) {
 
 function buttonPause() {
   if (gameState.pausedReasons.includes(pauseStates.MANUAL)) {
-    removePauseReason(pauseStates.MANUAL);
+    deletePauseState(pauseStates.MANUAL);
   } else {
-    addPauseReason(pauseStates.MANUAL, pauseStates.MANUAL, pauseStates.MANUAL);
+    addPauseState(pauseStates.MANUAL);
   }
-}
-
-function addPauseReason(reason, logText, buttonLabel) {
-  if (!gameState.pausedReasons.includes(reason)) {
-    gameState.pausedReasons.push(reason);
-    if (logText !== undefined) {
-      logPopupCombo(logText, 'secondary');
-    }
-  }
-  processPauseButton(buttonLabel);
-}
-
-function removePauseReason(reason, logText, buttonLabel) {
-  const index = gameState.pausedReasons.indexOf(reason);
-  if (index !== -1) {
-    gameState.pausedReasons.splice(index, 1);
-    if (logText !== undefined) {
-      logPopupCombo(logText, 'secondary');
-    }
-  }
-  processPauseButton(buttonLabel);
-}
-
-function clearPauseReasons() {
-  gameState.pausedReasons = [];
-  processPauseButton();
-}
-
-function processPauseButton(buttonLabel) {
-  if (buttonLabel === undefined) {
-    if (gameState.pausedReasons.includes(pauseStates.MANUAL)) {
-      buttonLabel = pauseStates.MANUAL;
-    } else if (gameState.pausedReasons.includes(pauseStates.MODAL)) {
-      buttonLabel = pauseStates.MODAL;
-    } else if (gameState.pausedReasons.includes(pauseStates.INACTIVE)) {
-      buttonLabel = pauseStates.INACTIVE;
-    } else {
-      buttonLabel = 'Running (▶)';
-    }
-  }
-
-  document.getElementById('pause-button').innerText = buttonLabel
-}
-
-function isGamePaused() {
-  return gameState.pausedReasons.length > 0;
 }
 
 function updateHealthBar(timeChange = 0) {
@@ -528,7 +482,7 @@ function showTooltip(event, text = 'Default') {
 
 function showResetPopup(){
   gameOver = true;
-  addPauseReason(pauseStates.MANUAL, undefined, pauseStates.MANUAL);
+  addPauseState(pauseStates.MANUAL);
   document.querySelectorAll('button:not(.menu-button)').forEach(btn => btn.disabled = true);
 
   const summaryList = document.getElementById('reset-summary');
@@ -578,7 +532,7 @@ function restartGame(){
 
   gameOver = false;
   initializeGame();
-  removePauseReason(pauseStates.MANUAL);
+  deletePauseState(pauseStates.MANUAL);
 }
 
 function hideTooltip() {

--- a/index.html
+++ b/index.html
@@ -159,9 +159,10 @@
   <!-- Bootstrap JS plugins -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 
-  <!-- Game scripts -->
-  <script src="./assets/scripts/initialize.js"></script>
-  <script src="./assets/scripts/action_functions.js"></script>
+    <!-- Game scripts -->
+    <script src="./assets/scripts/initialize.js"></script>
+    <script src="./assets/scripts/pause_helpers.js"></script>
+    <script src="./assets/scripts/action_functions.js"></script>
   <script src="./assets/scripts/action_effects.js"></script>
   <script src="./assets/scripts/script.js"></script>
   <script src="./assets/scripts/clock.js"></script>


### PR DESCRIPTION
## Summary
- Add `pause_helpers.js` with `addPauseState`, `deletePauseState`, `isGamePaused`, and UI updates
- Replace legacy pause functions in `script.js` with new helpers
- Load pause helpers after initialization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898324e7c588324a68b7032ff1f83b4