### PR TITLE
Fix Options button error by toggling settings pane

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -460,9 +460,21 @@ function openTab(tabId = 'None') {
         tabContents[i].classList.add('d-none');
     }
 
-    // Show the specific tab content
-    if (tabId !== 'None') {
-      document.getElementById(tabId).classList.remove('d-none');
+    // Hide both main and settings panes
+    var settingsPane = document.getElementById('settings-pane');
+    var mainPane = document.getElementById('main-pane');
+    if (settingsPane) settingsPane.classList.add('d-none');
+    if (mainPane) mainPane.classList.add('d-none');
+
+    // Show the specific pane/tab
+    if (tabId === 'settings-pane') {
+        if (settingsPane) settingsPane.classList.remove('d-none');
+    } else {
+        if (mainPane) mainPane.classList.remove('d-none');
+        if (tabId !== 'None') {
+            var tab = document.getElementById(tabId);
+            if (tab) tab.classList.remove('d-none');
+        }
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         <!-- Row for menu buttons -->
         <div class="row px-3">
             <button class="menu-button" onclick="openTab('actions-tab')">Main</button>
-            <button class="menu-button" onclick="openTab('settings-tab')">Options</button>
+            <button class="menu-button" onclick="openTab('settings-pane')">Options</button>
             <button class="menu-button" onclick="saveGame(true)">Save</button>
             <button class="menu-button" onclick="resetGameState()">Reset</button>
             <button class="menu-button" id="pause-button" onclick="buttonPause()">Pause</button>


### PR DESCRIPTION
## Summary
- Correct Options button to target the settings pane
- Update `openTab` to toggle main and settings panes and guard against missing elements

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check assets/scripts/script.js`


------
https://chatgpt.com/codex/tasks/task_e_689837960c7c8324af6f5c592dda85c1