### PR TITLE
Hide artifacts menu until discovery

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -208,15 +208,20 @@ let gameOver = false;
 
 function updateArtifactsUI() {
   const container = document.getElementById('artifact-list');
-  if (!container) {return;}
+  const tab = document.getElementById('artifacts-tab');
+  const button = document.getElementById('artifacts-button');
+  if (!container || !tab || !button) {return;}
   container.innerHTML = '';
   const unlocked = Object.keys(gameState.artifacts || {}).filter(id => gameState.artifacts[id]);
   if (unlocked.length === 0) {
-    const div = document.createElement('div');
-    div.textContent = 'No artifacts discovered yet.';
-    container.appendChild(div);
+    tab.classList.add('d-none');
+    tab.classList.remove('d-md-block');
+    button.classList.add('d-none');
     return;
   }
+  tab.classList.add('d-md-block');
+  tab.classList.remove('d-none');
+  button.classList.remove('d-none');
   unlocked.forEach(id => {
     const art = artifactData[id];
     if (!art) {return;}

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
               <button class="tab-button" onClick="openTab('actions-tab')">A</button>
               <button id="skills-button" class="tab-button d-none" onClick="openTab('skills-tab')">S</button>
               <button class="tab-button" onClick="openTab('log-tab')">L</button>
-              <button class="tab-button" onClick="openTab('artifacts-tab')">R</button>
+              <button id="artifacts-button" class="tab-button d-none" onClick="openTab('artifacts-tab')">R</button>
             </span>
           </div>
         </div>
@@ -141,7 +141,7 @@
               </div>
             </div>
             <!-- Artifacts -->
-            <div id="artifacts-tab" class="mobile-tab row d-none d-md-block">
+            <div id="artifacts-tab" class="mobile-tab row d-none">
               <div class="col" id="artifact-list"></div>
             </div>
             <!-- Actions and Game Log -->


### PR DESCRIPTION
## Summary
- Hide artifacts menu and button by default until an artifact is discovered
- Show artifacts tab and button when at least one artifact has been unlocked

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68983bf637108324af4a00c2449ecdaa