### PR TITLE
Highlight unstartable actions and hide completed

### DIFF
--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -46,9 +46,18 @@ class GameAction {
 			processActiveAndQueuedActions()
   }
 
-	get isAvailable() {return gameState.actionsAvailable.includes(this.id);}
-	get isActive() {return gameState.actionsActive.includes(this.id);}
-	get isQueued() {return gameState.actionsQueued.includes(this.id);}
+        get isAvailable() {return gameState.actionsAvailable.includes(this.id);}
+        get isActive() {return gameState.actionsActive.includes(this.id);}
+        get isQueued() {return gameState.actionsQueued.includes(this.id);}
+
+        canStart() {
+                if (!this.data || !this.progress) {return false;}
+                if (!this.isAvailable) {return false;}
+                if (this.progress.completions >= this.data.completionMax) {return false;}
+                const req = this.data.requirements;
+                const res = evaluateRequirements(req);
+                return res.ok;
+        }
 
         start() {
                 if (!this.data || !this.progress) {
@@ -324,10 +333,19 @@ function processActiveAndQueuedActions() {
 
   const queueExtrasThreshold = 3;
   Object.values(actionsConstructed).forEach(actionObject => {
-    // Color each active action blue, otherwise black
-    if (gameState.actionsActive.includes(actionObject.id) === true) {
+    if (actionObject.progress.completions >= actionObject.data.completionMax && !gameState.debugMode) {
+      actionObject.container.style.display = 'none';
+      return;
+    } else {
+      actionObject.container.style.display = 'block';
+    }
+
+    if (gameState.actionsActive.includes(actionObject.id)) {
       actionObject.elements.progressContainer.style.border = '2px solid blue';
       actionObject.elements.progressBarCurrent.classList.add('active');
+    } else if (!actionObject.canStart()) {
+      actionObject.elements.progressContainer.style.border = '2px solid red';
+      actionObject.elements.progressBarCurrent.classList.remove('active');
     } else {
       actionObject.elements.progressContainer.style.border = '2px solid black';
       actionObject.elements.progressBarCurrent.classList.remove('active');

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -18,6 +18,9 @@ document.addEventListener('DOMContentLoaded', () => {
     debugToggle.addEventListener('change', e => {
       gameState.debugMode = e.target.checked;
       saveGame();
+      if (typeof processActiveAndQueuedActions === 'function') {
+        processActiveAndQueuedActions();
+      }
     });
   }
   updateDebugToggle();


### PR DESCRIPTION
## Summary
- Show red borders on actions that cannot start and blue for active ones
- Automatically hide actions at max completions unless debug mode is on
- Refresh action visibility and borders when toggling debug mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68983c73de7c832483276c858bffce9e