### PR TITLE
Add time dilation API and debug slider

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -681,6 +681,13 @@ function initializeGame() {
     function apply() {
       const eff = getEffective();
 
+      // Maintain compatibility with legacy global variable if present
+      if (typeof timeDilation !== 'undefined') {
+        try {
+          timeDilation = eff;
+        } catch (_e) { /* ignore */ }
+      }
+
       // Prefer GlobalClock API if present
       if (window.gameClock && typeof gameClock.setTimeDilation === 'function') {
         gameClock.setTimeDilation(eff);

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -10,6 +10,28 @@ function updateDebugToggle() {
   if (debugToggle) {
     debugToggle.checked = gameState.debugMode;
   }
+  const controls = document.getElementById('time-dilation-controls');
+  if (controls) {
+    if (gameState.debugMode) {
+      controls.classList.remove('d-none');
+    } else {
+      controls.classList.add('d-none');
+    }
+  }
+  const slider = document.getElementById('time-dilation-slider');
+  if (slider) {
+    const base = gameState?.globalParameters?.timeDilationBase ?? gameState?.globalParameters?.timeDilation ?? 1;
+    slider.value = base;
+    updateTimeDilationDisplay();
+  }
+}
+
+function updateTimeDilationDisplay() {
+  const slider = document.getElementById('time-dilation-slider');
+  const disp = document.getElementById('time-dilation-display');
+  if (slider && disp) {
+    disp.textContent = Number(slider.value).toFixed(2);
+  }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -21,6 +43,16 @@ document.addEventListener('DOMContentLoaded', () => {
       if (typeof processActiveAndQueuedActions === 'function') {
         processActiveAndQueuedActions();
       }
+      updateDebugToggle();
+    });
+  }
+  const timeSlider = document.getElementById('time-dilation-slider');
+  if (timeSlider) {
+    timeSlider.addEventListener('input', e => {
+      if (typeof setTimeDilation === 'function') {
+        setTimeDilation(e.target.value);
+      }
+      updateTimeDilationDisplay();
     });
   }
   updateDebugToggle();

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -2,7 +2,8 @@
 let gameActive = true;
 let manualPause = false;
 let frameRate = 60;
-let timeDilation = 2;
+// Initialize legacy timeDilation variable from base game state
+let timeDilation = emptyGameState.globalParameters.timeDilation;
 let gameState = JSON.parse(JSON.stringify(emptyGameState));
 
 function updateDebugToggle() {
@@ -55,6 +56,14 @@ document.addEventListener('DOMContentLoaded', () => {
       updateTimeDilationDisplay();
     });
   }
+  document.addEventListener('time-dilation-changed', () => {
+    const slider = document.getElementById('time-dilation-slider');
+    if (slider) {
+      const base = gameState?.globalParameters?.timeDilationBase ?? gameState?.globalParameters?.timeDilation ?? 1;
+      slider.value = base;
+    }
+    updateTimeDilationDisplay();
+  });
   updateDebugToggle();
 });
 

--- a/index.html
+++ b/index.html
@@ -60,6 +60,10 @@
           <!-- Settings. Off by default. -->
           <div id="settings-pane" class="content-pane d-none col-12 full-height">
             <label><input type="checkbox" id="debug-toggle"> Debug mode</label>
+            <div id="time-dilation-controls" class="d-none mt-2">
+              <label for="time-dilation-slider" class="form-label">Time Dilation: <span id="time-dilation-display">1</span>x</label>
+              <input type="range" class="form-range" id="time-dilation-slider" min="0.05" max="5" step="0.05" value="1">
+            </div>
           </div>
           <!-- Main View. On by default. -->
           <div id="main-pane" class="content-pane col-12 full-height flex-vert">


### PR DESCRIPTION
## Summary
- Add non-destructive Time Dilation API enabling stacked runtime modifiers and debug hooks
- Introduce debug-only time dilation slider in Options
- Wire slider to API and update display when debug mode changes

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68984033a79483249b8e51549aecbba2