### PR TITLE
Ensure progress bar reaches full width before completing actions

### DIFF
--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -155,11 +155,12 @@ class GameAction {
 
     if (completed && !this.finishing) {
       this.finishing = true;
-      // Delay finish until the next frame so 100% progress renders
-      if (typeof requestAnimationFrame === 'function') {
-        requestAnimationFrame(() => this.finish());
+      // Wait two frames before finishing so the bar paints at 100%
+      const finalize = () => this.finish();
+      if (typeof requestAnimationFrame === "function") {
+        requestAnimationFrame(() => requestAnimationFrame(finalize));
       } else {
-        setTimeout(() => this.finish(), 0);
+        setTimeout(finalize, 0);
       }
     }
 

--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -48,7 +48,9 @@ class GameAction {
 
       this.calculateTimeStart();
       this.update();
-			processActiveAndQueuedActions()
+                        processActiveAndQueuedActions()
+      // Flag to avoid duplicate finish calls when progress completes
+      this.finishing = false;
   }
 
         get isAvailable() {return gameState.actionsAvailable.includes(this.id);}
@@ -135,8 +137,10 @@ class GameAction {
     this.progress.timeCurrent += newTimeChange;
     this.progress.mastery += newTimeChange;
 
+    let completed = false;
     if (this.progress.timeCurrent >= this.data.length) {
-      this.finish();
+      this.progress.timeCurrent = this.data.length;
+      completed = true;
     }
 
     this.calculateTimeStart();
@@ -148,6 +152,16 @@ class GameAction {
     this.elements.progressBarCurrent.style.width = currentPercentage + '%';
     this.elements.progressText.innerText = label;
     this.elements.progressBarMastery.style.width = masteryPercentage + '%';
+
+    if (completed && !this.finishing) {
+      this.finishing = true;
+      // Delay finish until the next frame so 100% progress renders
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => this.finish());
+      } else {
+        setTimeout(() => this.finish(), 0);
+      }
+    }
 
   }
 
@@ -170,6 +184,8 @@ class GameAction {
     }
 
     console.log(this.id);
+    // Allow future completions
+    this.finishing = false;
   }
 
   initializeActionProgress() {


### PR DESCRIPTION
## Summary
- Delay action completion until next animation frame so progress bar renders at 100%
- Track `finishing` state to avoid duplicate completion triggers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689849c69f548324a46790486cff1ebe