### PR TITLE
Refactor skill multiplier

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -37,12 +37,9 @@ function doSkillsExist(skillOrSkills) {
 }
 
 function multiplyTimeChangeBySkills(timeChange, skills){
-  // Abort if any skill is illegal
-  if (!doSkillsExist(skills)) {return timeChange;}
-
   let multipliers = skills.map(skill => {
-    currentLevel = gameState.skills[skill].current_level
-    permanentLevel = gameState.skills[skill].permanent_level
+    const currentLevel = gameState.skills[skill].current_level
+    const permanentLevel = gameState.skills[skill].permanent_level
 
     return Math.pow(1.1, currentLevel) * Math.pow(1.01, permanentLevel);
   });


### PR DESCRIPTION
## Summary
- Remove skill validation from multiplyTimeChangeBySkills and assume valid skills
- Use local constants for current and permanent skill levels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68984a3797f883249e865e5a86f4ea8b