### PR TITLE
Update skill progress threshold handling

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -70,7 +70,7 @@ function updateSkill(skill, timeChange) {
 
 
   skill_to_update.current_progress += timeChange;
-  if (skill_to_update.current_progress > currentExperienceToLevel) {
+  if (skill_to_update.current_progress >= currentExperienceToLevel) {
     skill_to_update.current_level += 1;
 
     skill_to_update.current_progress -= currentExperienceToLevel;
@@ -79,7 +79,7 @@ function updateSkill(skill, timeChange) {
 
 
   skill_to_update.permanent_progress += timeChange;
-  if (skill_to_update.permanent_progress > permanentExperienceToLevel) {
+  if (skill_to_update.permanent_progress >= permanentExperienceToLevel) {
     skill_to_update.permanent_level += 1;
     skill_to_update.permanent_progress -= permanentExperienceToLevel;
   }


### PR DESCRIPTION
## Summary
- Treat reaching exact experience thresholds as level-up for skills

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/otakat.github.io/package.json')

------
https://chatgpt.com/codex/tasks/task_e_68984a41567c8324a2081d0a68bc5793