### PR TITLE
Guard finish log with debug mode

### DIFF
--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -169,7 +169,7 @@ class GameAction {
       this.data.completionEffects.last(this.id);
     }
 
-    console.log(this.id);
+    if (gameState.debugMode) console.log(this.id);
   }
 
   initializeActionProgress() {


### PR DESCRIPTION
## Summary
- Only log action ID on finish when `gameState.debugMode` is enabled

## Testing
- `node --check assets/scripts/action_functions.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68984a6146e8832492d5b8c6212deb9d