### PR TITLE
Load action_effects before action_functions

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,10 +175,10 @@
     <!-- Game scripts -->
     <script src="./assets/scripts/initialize.js"></script>
     <script src="./assets/scripts/pause_helpers.js"></script>
+    <script src="./assets/scripts/action_effects.js"></script>
     <script src="./assets/scripts/action_functions.js"></script>
-  <script src="./assets/scripts/action_effects.js"></script>
-  <script src="./assets/scripts/script.js"></script>
-  <script src="./assets/scripts/clock.js"></script>
-  <script src="./assets/scripts/start.js"></script>
+    <script src="./assets/scripts/script.js"></script>
+    <script src="./assets/scripts/clock.js"></script>
+    <script src="./assets/scripts/start.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Ensure `action_effects.js` loads before `action_functions.js` in the main HTML so effect helpers are available

## Testing
- `node` (attempted jsdom load; failed due to missing external resources)

------
https://chatgpt.com/codex/tasks/task_e_68984a9480c48324aa949c98e908e780