### PR TITLE
refactor: clean up start script

### DIFF
--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -1,8 +1,5 @@
 /// INITIALIZATION ///
 
-let gameActive = true;
-let manualPause = false;
-let frameRate = 60;
 // Initialize legacy timeDilation variable from base game state
 let timeDilation = emptyGameState.globalParameters.timeDilation;
 let gameState = JSON.parse(JSON.stringify(emptyGameState));
@@ -72,4 +69,4 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 // Kickoff at clock zero
-window.onload = loadGame;
+window.addEventListener('load', loadGame);


### PR DESCRIPTION
## Summary
- remove unused variable declarations from `start.js`
- use `addEventListener('load', ...)` instead of `window.onload`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/otakat.github.io/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68984aa875448324a1f40c9bd0c7743f