### PR TITLE
Replace health with pocket watch countdown

### DIFF
--- a/assets/scripts/action_effects.js
+++ b/assets/scripts/action_effects.js
@@ -8,6 +8,10 @@ const artifactData = {
   timeCharm: {
     label: "Time Charm",
     description: "Increases all action speed by 10%."
+  },
+  pocketwatch: {
+    label: "Pocket Watch",
+    description: "Reveals the flow of time left in this loop."
   }
 };
 
@@ -15,7 +19,6 @@ const default_action = {
   label: "Default Action Name",
   length: 5000,
   skills: skillList,
-  healthCostMultiplier: 1.0,
   challengeType: 'generic',
   startEffects: {
     each: function(actionId) {return true;},
@@ -37,10 +40,10 @@ const default_action = {
 }
 
 const challengeMods = {
-  combat:   { speedMult: 1.0, healthCostMultiplier: 2.0 },
-  explore:  { speedMult: 1.1, healthCostMultiplier: 1.0 },
-  puzzle:   { speedMult: 0.9, healthCostMultiplier: 0.5 },
-  resource: { speedMult: 1.0, healthCostMultiplier: 0.8 }
+  combat:   { speedMult: 1.0 },
+  explore:  { speedMult: 1.1 },
+  puzzle:   { speedMult: 0.9 },
+  resource: { speedMult: 1.0 }
 };
 
 const book1_actions = {
@@ -49,11 +52,11 @@ const book1_actions = {
     length: 5000,
     skills: ["curiosity", "perseverance"],
     challengeType: 'explore',
-    healthCostMultiplier: 0.5,
     completionMax: 1,
     completionEffects: {
       1: function(actionId) {
         logPopupCombo('The trail leads you to a moonlit glade.', 'success');
+        unlockArtifact('pocketwatch');
         logPopupCombo('Unlocked: ' + book1_actions['book1_action2'].label + '.', 'primary');
         makeActionAvailable('book1_action2');
       },
@@ -84,7 +87,6 @@ const book1_actions = {
       ]
     },
     challengeType: 'combat',
-    healthCostMultiplier: 2.0,
     completionMax: 1,
     completionEffects: {
       1: function(actionId) {

--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -126,6 +126,7 @@ class GameAction {
                 // Process time change
     this.progress.timeCurrent += newTimeChange;
     this.progress.mastery += newTimeChange;
+    if (newTimeChange > 0) consumeTime(newTimeChange / 1000);
 
     if (this.progress.timeCurrent >= this.data.length) {
       this.finish();
@@ -305,9 +306,6 @@ function activateAction(actionId) {
 
   const ok = a.start();
   if (!ok) return false;
-
-  consumeTime((a.data.length ?? 0) / 1000);
-  if (timeRemaining <= 0) { return false; }
 
   const maxActive = gameState.globalParameters.actionsMaxActive;
   if (gameState.actionsActive.length >= maxActive) {

--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -121,7 +121,6 @@ class GameAction {
                 const mods = challengeMods[this.data.challengeType];
                 if (mods) {
                   newTimeChange *= mods.speedMult ?? 1;
-                  this.data.healthCostMultiplier = mods.healthCostMultiplier ?? this.data.healthCostMultiplier;
                 }
 
                 // Process time change
@@ -302,9 +301,13 @@ function activateAction(actionId) {
     a.start();
     processActiveAndQueuedActions();
     return true;
+  }
 
   const ok = a.start();
   if (!ok) return false;
+
+  consumeTime((a.data.length ?? 0) / 1000);
+  if (timeRemaining <= 0) { return false; }
 
   const maxActive = gameState.globalParameters.actionsMaxActive;
   if (gameState.actionsActive.length >= maxActive) {

--- a/assets/scripts/initialize.js
+++ b/assets/scripts/initialize.js
@@ -5,16 +5,23 @@ const pauseStates = {
   MODAL: 'Paused (Dialog Open)',
 };
 
+// Default loop time in seconds
+const defaultLoopTime = 600;
+
 const emptyGameState = {
   debugMode: false,
   actionsAvailable: ['book1_action1'],
   actionsActive: [],
   actionsProgress: {},
-  health: { current: 25000, max: 25000 },
+  // Countdown timer replaces health mechanic
+  timeRemaining: defaultLoopTime,
+  timeMax: defaultLoopTime,
+  hasPocketWatch: false,
   pausedReasons: [pauseStates.INACTIVE],
   gameLog: [],
   skills: {},
   artifacts: {},
+  timeWarnings: { half: false, quarter: false },
   globalParameters: {
     logicHz: 30,        // Gameplay logic ticks per second
     renderHz: 30,       // UI refresh rate in ticks per second

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -8,6 +8,10 @@ let timeDilation = emptyGameState.globalParameters.timeDilation;
 let gameState = JSON.parse(JSON.stringify(emptyGameState));
 let framesTotal = 0;    // Counts clock ticks since load
 let timeTotal = 0;      // Accumulates clock ms for scheduling
+let timeRemaining = defaultLoopTime; // seconds left in loop
+let timeMax = defaultLoopTime;       // maximum loop time in seconds
+let hasPocketWatch = false;
+let timeWarnings = { half: false, quarter: false };
 
 function updateDebugToggle() {
   const debugToggle = document.getElementById('debug-toggle');

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -109,42 +109,26 @@ body {
     cursor: pointer;
   }
 
-/* HEALTH BAR */
-#health-container {
+/* LOOP TIMER */
+#timer-container {
   flex: 0 0 auto;
   padding: 5px;
   border-radius: 5px;
   background-color: rgba(255,255,255,0.6);
 }
 
-  #health-bar-container {
-    position: relative;
-    width: 100%; height: 30px;
-    background-color: #555;
-    border-radius: 5px;
-    overflow: hidden;
-    border: 2px solid black;
-  }
+#timer-display {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+  font-size: 1.2em;
+  font-family: monospace;
+}
 
-  #health-bar {
-    position: relative;
-    width: 100%; height: 100%;
-    background-color: #880000; /* Red for health bar */
-    z-index:1;
-  }
-
-  #health-bar-text {
-    position: absolute; /* Position the text absolutely */
-    top: 0; left: 0;
-    width: 100%; height: 100%;
-    line-height: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: white; /* Choose a color that contrasts with the health bar */
-    font-size: 1em;
-    z-index:2;
-  }
+#timer-icon {
+  font-size: 1.2em;
+}
 
 /* TABS MENU */
 .tab-button-container {

--- a/index.html
+++ b/index.html
@@ -37,15 +37,11 @@
             <button class="menu-button" onclick="resetGameState()" data-bs-toggle="tooltip" data-bs-title="Erase progress">Reset</button>
             <button class="menu-button" id="pause-button" onclick="buttonPause()" data-bs-toggle="tooltip" data-bs-title="Toggle clock pause">Pause</button>
         </div>
-        <!-- Row for health bar -->
+        <!-- Row for loop timer -->
         <div class="row">
           <div class="col col-md-8 text-center">
-            <div id="health-container">
-              <span class="d-none d-md-block">Health</span>
-              <div id="health-bar-container">
-                  <div id="health-bar-text"># / #</div>
-                  <div id="health-bar"></div>
-              </div>
+            <div id="timer-container" class="d-none">
+              <div id="timer-display"><span id="timer-icon">&#x23F1;</span> <span id="time-remaining">00:00</span></div>
             </div>
             <div id="debug-overlay" style="display:none;"></div>
           </div>


### PR DESCRIPTION
## Summary
- Swap health drain for a loop timer using `timeRemaining`
- Gate the visible stopwatch behind the new Pocket Watch artifact
- Deduct time based on action `length` and persist a maximum `timeMax`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check assets/scripts/script.js`
- `node --check assets/scripts/action_functions.js`
- `node --check assets/scripts/initialize.js`
- `node --check assets/scripts/action_effects.js`
- `node --check assets/scripts/start.js`


------
https://chatgpt.com/codex/tasks/task_e_68990785bd108324a8c9daaa0a258f55