### PR TITLE
Consolidate pause helpers

### DIFF
--- a/assets/scripts/pause_helpers.js
+++ b/assets/scripts/pause_helpers.js
@@ -35,24 +35,10 @@ function processPauseButton(label) {
   if (el) el.innerText = text;
 }
 
-// Backwards compatibility helpers
-function addPauseReason(state, _logText, label) {
-  addPauseState(state);
-  if (label !== undefined) {
-    processPauseButton(label);
-  }
-}
-
-function removePauseReason(state, _logText, label) {
-  deletePauseState(state);
-  if (label !== undefined) {
-    processPauseButton(label);
-  }
-}
-
-function clearPauseReasons() {
-  deletePauseState();
-}
+// Backwards compatibility aliases
+const addPauseReason = addPauseState;
+const removePauseReason = deletePauseState;
+const clearPauseReasons = deletePauseState;
 
 // Optional property shim for old `gameState.paused` checks
 window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- simplify pause helper script by keeping add/delete state functions
- alias legacy pause helper names to new implementations

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68984a868c148324a145eb8ab7157895