### PR TITLE
Ensure unavailable actions show red border immediately

### DIFF
--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -43,7 +43,6 @@ class GameAction {
 
       this.calculateTimeStart();
       this.update();
-			processActiveAndQueuedActions()
   }
 
         get isAvailable() {
@@ -238,6 +237,7 @@ function createNewAction(id) {
   }
 
   actionsConstructed[id] = new GameAction(id);
+  processActiveAndQueuedActions();
 }
 
 // Access a constructed GameAction safely
@@ -279,6 +279,7 @@ function makeActionAvailable(actionId) {
       actionsConstructed[actionId].container.style.display = 'none';
     }
   }
+  processActiveAndQueuedActions();
 }
 
 function makeActionUnavailable(actionId) {

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -396,6 +396,7 @@ function runGameTick(stepMs) {
       actionsConstructed[actionId].update(stepMs);
     });
     processScheduledEvents();
+    processActiveAndQueuedActions();
   }
 }
 


### PR DESCRIPTION
## Summary
- Re-run action availability checks after constructing a new action so its border reflects startability immediately.
- Update `makeActionAvailable` to refresh action borders when actions are unlocked.
- Remove no-op border update from `GameAction` constructor.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68996ab4c9e88324af99844da3fa1678