### PR TITLE
Use worker-timers for clock accuracy

### DIFF
--- a/assets/scripts/clock.js
+++ b/assets/scripts/clock.js
@@ -10,23 +10,23 @@ function changeGlobalStyle(selector, property, value) {
 
 class GlobalClock {
   constructor() {
-    this.timer = null;
+    this.timerId = null;
     this.lastClockTime = performance.now();
     this.accumulator = 0;
     this.start();
   }
 
   start() {
-    if (this.timer) this.stop();
+    if (this.timerId) this.stop();
     this.lastClockTime = performance.now();
     const intervalMs = 1000 / gameState.globalParameters.renderHz;
-    this.timer = setInterval(() => this._beat(), intervalMs);
+    this.timerId = workerTimers.setInterval(() => this._beat(), intervalMs);
   }
 
   stop() {
-    if (this.timer) {
-      clearInterval(this.timer);
-      this.timer = null;
+    if (this.timerId) {
+      workerTimers.clearInterval(this.timerId);
+      this.timerId = null;
     }
   }
 

--- a/assets/scripts/clock.js
+++ b/assets/scripts/clock.js
@@ -20,12 +20,14 @@ class GlobalClock {
     if (this.timerId) this.stop();
     this.lastClockTime = performance.now();
     const intervalMs = 1000 / gameState.globalParameters.renderHz;
-    this.timerId = workerTimers.setInterval(() => this._beat(), intervalMs);
+    const timers = window.workerTimers || window;
+    this.timerId = timers.setInterval(() => this._beat(), intervalMs);
   }
 
   stop() {
     if (this.timerId) {
-      workerTimers.clearInterval(this.timerId);
+      const timers = window.workerTimers || window;
+      timers.clearInterval(this.timerId);
       this.timerId = null;
     }
   }

--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 
   <!-- Worker Timers for accurate intervals -->
-  <script src="https://cdn.jsdelivr.net/npm/worker-timers@^7/dist/worker-timers.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/worker-timers@7/dist/worker-timers.min.js"></script>
 
     <!-- Game scripts -->
     <script src="./assets/scripts/initialize.js"></script>

--- a/index.html
+++ b/index.html
@@ -168,6 +168,9 @@
   <!-- Bootstrap JS plugins -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 
+  <!-- Worker Timers for accurate intervals -->
+  <script src="https://cdn.jsdelivr.net/npm/worker-timers@^7/dist/worker-timers.min.js"></script>
+
     <!-- Game scripts -->
     <script src="./assets/scripts/initialize.js"></script>
     <script src="./assets/scripts/pause_helpers.js"></script>


### PR DESCRIPTION
## Summary
- Load worker-timers from CDN before game scripts
- Swap `setInterval`/`clearInterval` for `workerTimers.setInterval`/`workerTimers.clearInterval` in `GlobalClock`
- Ensure `GlobalClock` still initializes after worker-timers script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b9a9e2bb48324b011c2ce86ec1a29