### PR TITLE
Use Emittery event bus

### DIFF
--- a/assets/scripts/clock.js
+++ b/assets/scripts/clock.js
@@ -38,18 +38,18 @@ class GlobalClock {
     const gameDelta = clockDelta * gameState.globalParameters.timeDilation;
 
     // Emit events
-    document.dispatchEvent(new CustomEvent('heartbeat', { detail: { clockDelta } }));
+    eventBus.emit('heartbeat', { clockDelta });
 
     // Fixed-step logic accumulator
     const stepMs = 1000 / gameState.globalParameters.logicHz;
     this.accumulator += gameDelta;
     while (this.accumulator >= stepMs) {
-      document.dispatchEvent(new CustomEvent('tick-fixed', { detail: { stepMs } }));
+      eventBus.emit('tick-fixed', { stepMs });
       this.accumulator -= stepMs;
     }
 
     // Variable-step game tick
-    document.dispatchEvent(new CustomEvent('tick', { detail: { gameDelta } }));
+    eventBus.emit('tick', { gameDelta });
 
     // Update clock in gameState
     const paused = (typeof isGamePaused === 'function') ? isGamePaused() : false;
@@ -79,13 +79,13 @@ class GlobalClock {
   setTimeDilation(multiplier) {
     const clamped = Math.min(Math.max(multiplier, 0.05), 100);
     gameState.globalParameters.timeDilation = clamped;
-    document.dispatchEvent(new CustomEvent('time-dilation-changed', { detail: { timeDilation: clamped } }));
+    eventBus.emit('time-dilation-changed', { timeDilation: clamped });
   }
 }
 
 let totalTicks = 0;
 
-document.addEventListener('heartbeat', () => {
+eventBus.on('heartbeat', () => {
   totalTicks += 1;
   const overlay = document.getElementById('debug-overlay');
   if (!overlay) return;
@@ -105,7 +105,7 @@ document.addEventListener('heartbeat', () => {
 
 window.addEventListener('load', () => {
   window.gameClock = new GlobalClock();
-  document.addEventListener('heartbeat', () => {
+  eventBus.on('heartbeat', () => {
     if (gameState.debugMode) console.log('Tick!');
   });
 });

--- a/assets/scripts/initialize.js
+++ b/assets/scripts/initialize.js
@@ -1,3 +1,5 @@
+window.eventBus = new Emittery();
+
 // States allowed for gameState.paused
 const pauseStates = {
   MANUAL: 'Paused (Manual)',

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -401,7 +401,7 @@ function runGameTick(stepMs) {
 }
 
 // Listen for each fixed clock beat
-document.addEventListener('tick-fixed', e => runGameTick(e.detail.stepMs));
+eventBus.on('tick-fixed', ({ stepMs }) => runGameTick(stepMs));
 
 function buttonPause() {
   if (gameState.pausedReasons.includes(pauseStates.MANUAL)) {
@@ -743,11 +743,7 @@ function showTimeRemaining() { console.log('Time remaining:', timeRemaining + '/
         if (window.gameState && gameState.globalParameters) {
           gameState.globalParameters.timeDilation = eff;
         }
-        try {
-          document.dispatchEvent(
-            new CustomEvent('time-dilation-changed', { detail: { timeDilation: eff } })
-          );
-        } catch (_e) { /* ignore */ }
+        eventBus.emit('time-dilation-changed', { timeDilation: eff });
       }
       return eff;
     }
@@ -772,9 +768,9 @@ function showTimeRemaining() { console.log('Time remaining:', timeRemaining + '/
 
   // Optional: lightweight console trace when dilation changes (only attach once)
   if (!window.__td_logger_attached__) {
-    document.addEventListener('time-dilation-changed', (e) => {
-      if (e?.detail?.timeDilation != null) {
-        console.debug('[TimeDilation] effective =', e.detail.timeDilation);
+    eventBus.on('time-dilation-changed', ({ timeDilation }) => {
+      if (timeDilation != null) {
+        console.debug('[TimeDilation] effective =', timeDilation);
       }
     });
     window.__td_logger_attached__ = true;

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -122,7 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
       updateTimeDilationDisplay();
     });
   }
-  document.addEventListener('time-dilation-changed', () => {
+  eventBus.on('time-dilation-changed', () => {
     const slider = document.getElementById('time-dilation-slider');
     if (slider) {
       const base = gameState?.globalParameters?.timeDilationBase ?? gameState?.globalParameters?.timeDilation ?? 1;

--- a/index.html
+++ b/index.html
@@ -165,6 +165,7 @@
     </div>
   </div>
 
+  <script src="https://unpkg.com/emittery/umd/emittery.min.js"></script>
   <!-- Bootstrap JS plugins -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 


### PR DESCRIPTION
## Summary
- Load Emittery and create a shared `eventBus`
- Emit clock and time dilation events through the new bus
- Replace DOM `addEventListener` hooks with `eventBus.on`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b9aaf01a083248a88c8f373f99437