### PR TITLE
Use localforage for async game persistence

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -597,34 +597,39 @@ function resetGameState() {
   if (typeof updateDebugToggle === 'function') { updateDebugToggle(); }
 }
 
-function saveGame(isManualSave = false) {
-    try {
-      localStorage.setItem('gameState', JSON.stringify(gameState));
-      if (isManualSave) {logPopupCombo('Game Saved', 'secondary');}
-    } catch (error) {
-      const errorMessage = 'Error saving to local storage';
-      logPopupCombo(errorMessage, 'danger');
-      console.error(errorMessage);
-    }
-
+async function saveGame(isManualSave = false) {
+  try {
+    await localforage.setItem('gameState', gameState);
+    if (isManualSave) { logPopupCombo('Game Saved', 'secondary'); }
+  } catch (error) {
+    const errorMessage = 'Error saving game data';
+    logPopupCombo(errorMessage, 'danger');
+    console.error(errorMessage, error);
+  }
 }
 
-function loadGame() {
-  const savedState = localStorage.getItem('gameState');
-  if (savedState) {
-    const savedGameState = JSON.parse(savedState);
+async function loadGame() {
+  try {
+    const savedState = await localforage.getItem('gameState');
+    if (savedState) {
+      const savedGameState = savedState;
 
-    // Merge the saved game state with the empty game state
-    // This ensures new variables in emptyGameState are initialized properly
-    gameState = aggregateObjectProperties(emptyGameState, savedGameState);
+      // Merge the saved game state with the empty game state
+      // This ensures new variables in emptyGameState are initialized properly
+      gameState = aggregateObjectProperties(emptyGameState, savedGameState);
 
-    timeMax = gameState.timeMax ?? gameState.timeStart ?? defaultLoopTime;
-    timeRemaining = gameState.timeRemaining ?? timeMax;
-    hasPocketWatch = gameState.hasPocketWatch ?? false;
-    timeWarnings = gameState.timeWarnings || { half: false, quarter: false };
-    gameState.timeMax = timeMax;
+      timeMax = gameState.timeMax ?? gameState.timeStart ?? defaultLoopTime;
+      timeRemaining = gameState.timeRemaining ?? timeMax;
+      hasPocketWatch = gameState.hasPocketWatch ?? false;
+      timeWarnings = gameState.timeWarnings || { half: false, quarter: false };
+      gameState.timeMax = timeMax;
 
-    logPopupCombo('Data Loaded', 'secondary');
+      logPopupCombo('Data Loaded', 'secondary');
+    }
+  } catch (error) {
+    const errorMessage = 'Error loading game data';
+    logPopupCombo(errorMessage, 'danger');
+    console.error(errorMessage, error);
   }
 
   updateDebugToggle();

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -136,4 +136,10 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 // Kickoff at clock zero
-window.addEventListener('load', loadGame);
+window.addEventListener('load', async () => {
+  try {
+    await loadGame();
+  } catch (error) {
+    console.error(error);
+  }
+});

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
         <div class="row px-3">
             <button class="menu-button" onclick="openTab('actions-tab')">Main</button>
             <button class="menu-button" onclick="openTab('settings-pane')">Options</button>
-            <button class="menu-button" onclick="saveGame(true)" data-bs-toggle="tooltip" data-bs-title="Store progress">Save</button>
+            <button class="menu-button" onclick="saveGame(true).catch(console.error)" data-bs-toggle="tooltip" data-bs-title="Store progress">Save</button>
             <button class="menu-button" onclick="resetGameState()" data-bs-toggle="tooltip" data-bs-title="Erase progress">Reset</button>
             <button class="menu-button" id="pause-button" onclick="buttonPause()" data-bs-toggle="tooltip" data-bs-title="Toggle clock pause">Pause</button>
         </div>
@@ -167,6 +167,7 @@
 
   <!-- Bootstrap JS plugins -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/localforage@^1/dist/localforage.min.js"></script>
 
     <!-- Game scripts -->
     <script src="./assets/scripts/initialize.js"></script>


### PR DESCRIPTION
## Summary
- load localforage from CDN and handle async save via button
- convert saveGame/loadGame to async functions using localforage
- ensure loadGame is awaited on window load with error logging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b9ac592fc83248c08269d056b4789