### PR TITLE
Enable debug mode by default

### DIFF
--- a/assets/scripts/initialize.js
+++ b/assets/scripts/initialize.js
@@ -18,7 +18,7 @@ const pauseStates = {
 const defaultLoopTime = 600;
 
 const emptyGameState = {
-  debugMode: false,
+  debugMode: true,
   actionsAvailable: [],
   actionsActive: [],
   actionsProgress: {},

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
         <div class="row row-fix">
           <!-- Settings. Off by default. -->
           <div id="settings-pane" class="content-pane d-none col-12 full-height">
-            <label><input type="checkbox" id="debug-toggle"> Debug mode</label>
+            <label><input type="checkbox" id="debug-toggle" checked> Debug mode</label>
             <div id="time-dilation-controls" class="d-none mt-2">
               <label for="time-dilation-slider" class="form-label">Time Dilation: <span id="time-dilation-display">1</span>x</label>
               <input type="range" class="form-range" id="time-dilation-slider" min="0.05" max="5" step="0.05" value="1">


### PR DESCRIPTION
## Summary
- Turn on debug mode in the initial game state so development tools are active on load.
- Check the debug option checkbox by default in the options menu.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a24155cb348324adf711d2a1ac9436