### PR TITLE
Fix event bus initialization order

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,23 +215,22 @@
   </script>
   
   <!-- Bootstrap JS plugins -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/worker-timers@7/dist/worker-timers.min.js"></script>
-  <script src="https://unpkg.com/@popperjs/core@^2/dist/umd/popper.min.js"></script>
-  <script src="https://unpkg.com/tippy.js@^6/dist/tippy-bundle.umd.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/localforage@^1/dist/localforage.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous" defer></script>
+  <script src="https://unpkg.com/@popperjs/core@^2/dist/umd/popper.min.js" defer></script>
+  <script src="https://unpkg.com/tippy.js@^6/dist/tippy-bundle.umd.min.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/localforage@^1/dist/localforage.min.js" defer></script>
 
     <!-- Game scripts -->
-    <script src="./assets/scripts/initialize.js"></script>
-    <script src="./assets/scripts/pause_helpers.js"></script>
-    <script src="./assets/scripts/conditions.js"></script>
-      <script src="./assets/scripts/action_registry.js"></script>
-      <script src="./assets/scripts/action_runner.js"></script>
-      <script src="./assets/scripts/action_functions.js"></script>
-    <script src="./assets/scripts/script.js"></script>
-    <script src="./assets/scripts/clock.js"></script>
-    <script src="./assets/scripts/start.js"></script>
-    <script src="./assets/scripts/ui.js"></script>
+    <script src="./assets/scripts/initialize.js" defer></script>
+    <script src="./assets/scripts/pause_helpers.js" defer></script>
+    <script src="./assets/scripts/conditions.js" defer></script>
+      <script src="./assets/scripts/action_registry.js" defer></script>
+      <script src="./assets/scripts/action_runner.js" defer></script>
+      <script src="./assets/scripts/action_functions.js" defer></script>
+    <script src="./assets/scripts/script.js" defer></script>
+    <script src="./assets/scripts/clock.js" defer></script>
+    <script src="./assets/scripts/start.js" defer></script>
+    <script src="./assets/scripts/ui.js" defer></script>
 
 
 


### PR DESCRIPTION
## Summary
- Defer game and vendor scripts so the event bus module initializes before usage
- Drop failing worker-timers CDN script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a249a746c0832493327c3e1ad39314