### PR TITLE
Add reset button and refresh rate control to settings

### DIFF
--- a/assets/scripts/clock.js
+++ b/assets/scripts/clock.js
@@ -1,6 +1,17 @@
 function changeGlobalStyle(selector, property, value) {
   for (let sheet of document.styleSheets) {
-    for (let rule of sheet.cssRules) {
+    // Skip cross-origin stylesheets to avoid security errors
+    if (sheet.href && new URL(sheet.href).origin !== window.location.origin) {
+      continue;
+    }
+    let rules;
+    try {
+      rules = sheet.cssRules;
+    } catch (e) {
+      // Accessing cssRules can throw if the sheet is not accessible
+      continue;
+    }
+    for (let rule of rules) {
       if (rule.selectorText === selector) {
         rule.style[property] = value;
       }

--- a/assets/scripts/clock.js
+++ b/assets/scripts/clock.js
@@ -89,19 +89,18 @@ let totalTicks = 0;
 
 eventBus.on('heartbeat', () => {
   totalTicks += 1;
-  const overlay = document.getElementById('debug-overlay');
-  if (!overlay) return;
+  const info = document.getElementById('debug-info');
+  if (!info) return;
 
   if (gameState.debugMode) {
     const paused = (typeof isGamePaused === 'function') ? isGamePaused() : false;
-    overlay.style.display = 'block';
-    overlay.innerText =
+    info.textContent =
       `Render Hz: ${gameState.globalParameters.renderHz}\n` +
       `Logic Hz: ${gameState.globalParameters.logicHz}\n` +
       `Total Ticks: ${totalTicks}\n` +
       `Paused: ${paused}`;
   } else {
-    overlay.style.display = 'none';
+    info.textContent = '';
   }
 });
 

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -591,6 +591,9 @@ function resetGameState() {
   gameState.timeMax = timeMax;
   gameState.hasPocketWatch = hasPocketWatch;
   gameState.timeWarnings = { ...timeWarnings };
+  if (window.gameClock && typeof gameClock.setRenderHz === 'function') {
+    gameClock.setRenderHz(gameState.globalParameters.renderHz);
+  }
   updateTimerUI();
 
   const skillsTab = document.getElementById('skills-tab');
@@ -628,6 +631,9 @@ async function loadGame() {
       hasPocketWatch = gameState.hasPocketWatch ?? false;
       timeWarnings = gameState.timeWarnings || { half: false, quarter: false };
       gameState.timeMax = timeMax;
+      if (window.gameClock && typeof gameClock.setRenderHz === 'function') {
+        gameClock.setRenderHz(gameState.globalParameters?.renderHz || 30);
+      }
 
       logPopupCombo('Data Loaded', 'secondary');
     }

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -210,7 +210,7 @@ function updateArtifactsUI() {
   if (!container || !tab || !button) {return;}
   container.innerHTML = '';
   const unlocked = Object.keys(gameState.artifacts || {}).filter(id => gameState.artifacts[id]);
-  if (unlocked.length === 0) {
+  if (unlocked.length === 0 && !gameState.debugMode) {
     tab.classList.add('d-none');
     tab.classList.remove('d-md-block');
     button.classList.add('d-none');
@@ -597,9 +597,9 @@ function resetGameState() {
   updateTimerUI();
 
   const skillsTab = document.getElementById('skills-tab');
-  if (skillsTab) {skillsTab.classList.add('d-none'); skillsTab.classList.remove('d-md-block');}
+  if (skillsTab && !gameState.debugMode) {skillsTab.classList.add('d-none'); skillsTab.classList.remove('d-md-block');}
   const skillsButton = document.getElementById('skills-button');
-  if (skillsButton) {skillsButton.classList.add('d-none');}
+  if (skillsButton && !gameState.debugMode) {skillsButton.classList.add('d-none');}
 
   initializeGame();
   if (typeof updateDebugToggle === 'function') { updateDebugToggle(); }

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -43,6 +43,24 @@ function updateDebugToggle() {
     }
   }
 
+  const artTab = document.getElementById('artifacts-tab');
+  const artBtn = document.getElementById('artifacts-button');
+  const skillTab = document.getElementById('skills-tab');
+  const skillBtn = document.getElementById('skills-button');
+
+  if (gameState.debugMode) {
+    if (artTab) { artTab.classList.add('d-md-block'); artTab.classList.remove('d-none'); }
+    if (artBtn) { artBtn.classList.remove('d-none'); }
+    if (skillTab) { skillTab.classList.add('d-md-block'); skillTab.classList.remove('d-none'); }
+    if (skillBtn) { skillBtn.classList.remove('d-none'); }
+  } else {
+    if (typeof updateArtifactsUI === 'function') { updateArtifactsUI(); }
+    if (!gameState.artifacts?.skillbook) {
+      if (skillTab) { skillTab.classList.add('d-none'); skillTab.classList.remove('d-md-block'); }
+      if (skillBtn) { skillBtn.classList.add('d-none'); }
+    }
+  }
+
   if (gameState.debugMode) {
     window.DEBUG = {
       giveArtifact(id) {

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -15,6 +15,11 @@ function updateDebugToggle() {
   if (debugToggle) {
     debugToggle.checked = gameState.debugMode;
   }
+  const renderSlider = document.getElementById('render-rate-slider');
+  if (renderSlider) {
+    renderSlider.value = gameState?.globalParameters?.renderHz ?? 30;
+    updateRenderRateDisplay();
+  }
   const controls = document.getElementById('time-dilation-controls');
   if (controls) {
     if (gameState.debugMode) {
@@ -28,6 +33,14 @@ function updateDebugToggle() {
     const base = gameState?.globalParameters?.timeDilationBase ?? gameState?.globalParameters?.timeDilation ?? 1;
     slider.value = base;
     updateTimeDilationDisplay();
+  }
+  const debugInfo = document.getElementById('debug-info');
+  if (debugInfo) {
+    if (gameState.debugMode) {
+      debugInfo.classList.remove('d-none');
+    } else {
+      debugInfo.classList.add('d-none');
+    }
   }
 
   if (gameState.debugMode) {
@@ -102,6 +115,14 @@ function updateTimeDilationDisplay() {
   }
 }
 
+function updateRenderRateDisplay() {
+  const slider = document.getElementById('render-rate-slider');
+  const disp = document.getElementById('render-rate-display');
+  if (slider && disp) {
+    disp.textContent = Number(slider.value);
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const debugToggle = document.getElementById('debug-toggle');
   if (debugToggle) {
@@ -120,6 +141,26 @@ document.addEventListener('DOMContentLoaded', () => {
         setTimeDilation(e.target.value);
       }
       updateTimeDilationDisplay();
+    });
+  }
+  const renderSlider = document.getElementById('render-rate-slider');
+  if (renderSlider) {
+    renderSlider.addEventListener('input', e => {
+      const hz = Number(e.target.value);
+      if (window.gameClock && typeof gameClock.setRenderHz === 'function') {
+        gameClock.setRenderHz(hz);
+      } else {
+        if (!gameState.globalParameters) gameState.globalParameters = {};
+        gameState.globalParameters.renderHz = hz;
+      }
+      updateRenderRateDisplay();
+    });
+  }
+  const resetButton = document.getElementById('reset-game-button');
+  if (resetButton) {
+    resetButton.addEventListener('click', () => {
+      resetGameState();
+      saveGame().catch(console.error);
     });
   }
   eventBus.on('time-dilation-changed', () => {

--- a/index.html
+++ b/index.html
@@ -172,11 +172,19 @@
 
           <!-- Settings. Off by default. -->
           <div id="settings-pane" class="content-pane d-none col-12 full-height">
-            <label><input type="checkbox" id="debug-toggle"> Debug mode</label>
+            <div class="mb-3">
+              <label for="render-rate-slider" class="form-label">Refresh Rate: <span id="render-rate-display">30</span> Hz</label>
+              <input type="range" class="form-range" id="render-rate-slider" min="5" max="60" step="5" value="30">
+            </div>
+            <div class="mb-3">
+              <button id="reset-game-button" class="btn btn-danger">Reset Game</button>
+            </div>
+            <label class="mb-2"><input type="checkbox" id="debug-toggle"> Debug mode</label>
             <div id="time-dilation-controls" class="d-none mt-2">
               <label for="time-dilation-slider" class="form-label">Time Dilation: <span id="time-dilation-display">1</span>x</label>
               <input type="range" class="form-range" id="time-dilation-slider" min="0.05" max="5" step="0.05" value="1">
             </div>
+            <pre id="debug-info" class="d-none mt-3"></pre>
           </div>
           <!-- Library View -->
           <div id="library-pane" class="content-pane d-none col-12 full-height text-center p-3">
@@ -193,7 +201,6 @@
             <div id="timer-container" class="d-none align-self-end">
               <div id="timer-display"><span id="timer-icon">&#x23F1;</span> <span id="time-remaining">00:00</span></div>
             </div>
-            <div id="debug-overlay" style="display:none;"></div>
             <div class="row row-col-1 row-col-md-2 row-fix">
               <div id="actions-tab" class="mobile-tab col d-md-block full-height scroll">
                 <div id="all-actions-container" class="col full-height scroll"></div>


### PR DESCRIPTION
## Summary
- Add refresh-rate slider and game reset button to settings menu
- Move debug info panel into settings and wire display updates
- Persist render rate and apply on load and reset

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a24e687a48832495bbe1c3529fe811