### PR TITLE
Preserve pause button emoji when description updates

### DIFF
--- a/assets/scripts/pause_helpers.js
+++ b/assets/scripts/pause_helpers.js
@@ -32,7 +32,14 @@ function processPauseButton(label) {
     text = 'Running';
   }
   const el = document.getElementById('pause-button');
-  if (el) el.innerText = text;
+  if (el) {
+    const labelSpan = el.querySelector('.label');
+    if (labelSpan) {
+      labelSpan.innerText = text;
+    } else {
+      el.innerText = text;
+    }
+  }
 }
 
 // Backwards compatibility aliases


### PR DESCRIPTION
## Summary
- Update pause button handling to modify only the text label so the emoji remains constant

## Testing
- `node -c assets/scripts/pause_helpers.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a24ee9a13883248748581fd1912eea