### PR TITLE
Hide menu buttons by default and show with debug

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -210,7 +210,7 @@ function updateArtifactsUI() {
   if (!container || !tab || !button) {return;}
   container.innerHTML = '';
   const unlocked = Object.keys(gameState.artifacts || {}).filter(id => gameState.artifacts[id]);
-  if (unlocked.length === 0) {
+  if (unlocked.length === 0 && !gameState.debugMode) {
     tab.classList.add('d-none');
     tab.classList.remove('d-md-block');
     button.classList.add('d-none');
@@ -238,14 +238,41 @@ function updateArtifactsUI() {
 
 function applyArtifactEffects(id) {
   if (id === 'skillbook') {
-    const skillsTab = document.getElementById('skills-tab');
-    if (skillsTab) {
-      skillsTab.classList.add('d-md-block');
-      skillsTab.classList.remove('d-none');
-    }
-    const skillsButton = document.getElementById('skills-button');
-    if (skillsButton) {skillsButton.classList.remove('d-none');}
+    updateSkillsUI();
   }
+}
+
+function updateSkillsUI() {
+  const skillsTab = document.getElementById('skills-tab');
+  const skillsButton = document.getElementById('skills-button');
+  if (!skillsTab || !skillsButton) {return;}
+  const skillbookUnlocked = !!gameState.artifacts?.skillbook;
+  if (gameState.debugMode || skillbookUnlocked) {
+    skillsTab.classList.add('d-md-block');
+    skillsTab.classList.remove('d-none');
+    skillsButton.classList.remove('d-none');
+  } else {
+    skillsTab.classList.add('d-none');
+    skillsTab.classList.remove('d-md-block');
+    skillsButton.classList.add('d-none');
+  }
+}
+
+function updateLibraryButton() {
+  const libraryButton = document.getElementById('library-button');
+  if (!libraryButton) {return;}
+  const libraryUnlocked = !!gameState.flags?.libraryUnlocked;
+  if (gameState.debugMode || libraryUnlocked) {
+    libraryButton.classList.remove('d-none');
+  } else {
+    libraryButton.classList.add('d-none');
+  }
+}
+
+function updateMenuButtons() {
+  updateLibraryButton();
+  updateSkillsUI();
+  updateArtifactsUI();
 }
 
 function unlockArtifact(id) {
@@ -593,11 +620,6 @@ function resetGameState() {
   gameState.timeWarnings = { ...timeWarnings };
   updateTimerUI();
 
-  const skillsTab = document.getElementById('skills-tab');
-  if (skillsTab) {skillsTab.classList.add('d-none'); skillsTab.classList.remove('d-md-block');}
-  const skillsButton = document.getElementById('skills-button');
-  if (skillsButton) {skillsButton.classList.add('d-none');}
-
   initializeGame();
   if (typeof updateDebugToggle === 'function') { updateDebugToggle(); }
 }
@@ -667,7 +689,7 @@ function initializeGame() {
   Object.keys(gameState.artifacts).forEach(id => {
     if (gameState.artifacts[id]) {applyArtifactEffects(id);}
   });
-  updateArtifactsUI();
+  updateMenuButtons();
 }
 
 // Debug helpers

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -30,6 +30,8 @@ function updateDebugToggle() {
     updateTimeDilationDisplay();
   }
 
+  if (typeof updateMenuButtons === 'function') { updateMenuButtons(); }
+
   if (gameState.debugMode) {
     window.DEBUG = {
       giveArtifact(id) {

--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
         </div>
         <!-- Game menu row -->
         <div class="row px-3 game-menu">
-            <button class="menu-button menu-icon-button" id="library-button" onclick="showLibrary()">
+            <button class="menu-button menu-icon-button d-none" id="library-button" onclick="showLibrary()">
               <span class="emoji">📚</span><span class="label">Library</span>
             </button>
             <button class="menu-button menu-icon-button" id="book-button" onclick="showBook()">


### PR DESCRIPTION
## Summary
- Hide Library menu button initially and manage Library/Artifacts/Skills buttons via new updateMenuButtons helpers
- Extend debug toggle to reevaluate menu visibility, exposing buttons when enabled
- Integrate skills UI and artifact updates into menu visibility logic

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check assets/scripts/script.js`
- `node --check assets/scripts/start.js`


------
https://chatgpt.com/codex/tasks/task_e_68a24f5904248324a343607be6ce87a6