### PR TITLE
Display progress for all skills

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -91,11 +91,13 @@ function updateSkill(skill, timeChange) {
   permanentLevelEl.innerText = 'Permanent: ' + skill_to_update.permanent_level;
   permanentProgressEl.style.width = permanentProgressPercentage + '%';
 
-  if (Math.max(skill_to_update.current_level, skill_to_update.current_progress, skill_to_update.permanent_level, skill_to_update.permanent_progress) <= 0) {
-    skillEl.classList.add('d-none');
-  } else {
-    skillEl.classList.remove('d-none');
-  }
+  skillEl.classList.remove('d-none');
+}
+
+function refreshSkillsUI() {
+  skillList.forEach(skill => {
+    updateSkill(skill, 0);
+  });
 }
 
 function generateUniqueId() {
@@ -679,12 +681,7 @@ function initializeGame() {
   processPauseButton();
   processActiveAndQueuedActions();
   updateTimerUI();
-  updateSkill("courage", 0);
-  updateSkill("creativity", 0);
-  updateSkill("curiosity", 0);
-  updateSkill("integrity", 0);
-  updateSkill("perseverance", 0);
-  updateSkill("resourcefulness", 0);
+  refreshSkillsUI();
   recordStartingPermanentLevels();
   Object.keys(gameState.artifacts).forEach(id => {
     if (gameState.artifacts[id]) {applyArtifactEffects(id);}

--- a/assets/scripts/ui.js
+++ b/assets/scripts/ui.js
@@ -37,6 +37,7 @@ function updateLibrarySelection() {
 }
 
 function openSkills() {
+  if (typeof refreshSkillsUI === 'function') { refreshSkillsUI(); }
   const modal = new bootstrap.Modal(document.getElementById('skillsModal'));
   modal.show();
 }

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -215,7 +215,7 @@ body {
         }
 
         .skill-current-bar, .skill-permanent-bar {
-          height:20px; width: 60%;
+          height:20px; width: 0;
           position:absolute;
           top:0; left:0;
           line-height: 20px;


### PR DESCRIPTION
## Summary
- Ensure skill progress bars render for current and permanent levels
- Refresh skill displays when the Skills menu opens and during game initialization
- Adjust skill bar styles so progress starts at zero width

## Testing
- ❌ `npm test` *(package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a256e6ffa483248693a8970a814019