### PR TITLE
Add log tab and book story header

### DIFF
--- a/assets/scripts/action_registry.js
+++ b/assets/scripts/action_registry.js
@@ -66,7 +66,7 @@ const actionRegistry = {
           completionMax: 1,
           completionEffects: {
             1: function(actionId) {
-              logPopupCombo(getActionData(actionId).story.completion, 'success');
+              logPopupCombo(getActionData(actionId).story.completion, 'success', undefined, 'story');
               unlockArtifact('pocketwatch');
               const nextId = 'book1.hemlockForest.brewLanternOfDawn';
               logPopupCombo('Unlocked: ' + getActionData(nextId).label + '.', 'primary');
@@ -84,7 +84,7 @@ const actionRegistry = {
           completionMax: 10,
           completionEffects: {
             1: function(actionId) {
-              logPopupCombo(getActionData(actionId).story.completion, 'success');
+              logPopupCombo(getActionData(actionId).story.completion, 'success', undefined, 'story');
               const nextId = 'book1.hemlockForest.aidSilentKnight';
               logPopupCombo('Unlocked: ' + getActionData(nextId).label + '.', 'primary');
               makeActionAvailable(nextId);
@@ -109,7 +109,7 @@ const actionRegistry = {
           completionMax: 1,
           completionEffects: {
             1: function(actionId) {
-              logPopupCombo(getActionData(actionId).story.completion, 'success');
+              logPopupCombo(getActionData(actionId).story.completion, 'success', undefined, 'story');
               const nextId = 'book1.hemlockForest.crossEchoingBridge';
               logPopupCombo('Unlocked: ' + getActionData(nextId).label + '.', 'primary');
               makeActionAvailable(nextId);
@@ -126,7 +126,7 @@ const actionRegistry = {
           completionMax: 1,
           completionEffects: {
             1: function(actionId) {
-              logPopupCombo(getActionData(actionId).story.completion, 'success');
+              logPopupCombo(getActionData(actionId).story.completion, 'success', undefined, 'story');
               const nextId = 'book1.hemlockForest.meetDreamspinner';
               logPopupCombo('Unlocked: ' + getActionData(nextId).label + '.', 'primary');
               makeActionAvailable(nextId);
@@ -143,7 +143,7 @@ const actionRegistry = {
           completionMax: 1,
           completionEffects: {
             1: function(actionId) {
-              logPopupCombo(getActionData(actionId).story.completion, 'success');
+              logPopupCombo(getActionData(actionId).story.completion, 'success', undefined, 'story');
               const nextId = 'book1.hemlockForest.faceMirrorTyrant';
               logPopupCombo('Unlocked: ' + getActionData(nextId).label + '.', 'primary');
               makeActionAvailable(nextId);
@@ -160,7 +160,7 @@ const actionRegistry = {
           completionMax: 1,
           completionEffects: {
             1: function(actionId) {
-              logPopupCombo(getActionData(actionId).story.completion, 'success');
+              logPopupCombo(getActionData(actionId).story.completion, 'success', undefined, 'story');
               const nextId = 'book1.hemlockForest.awakenKingdom';
               logPopupCombo('Unlocked: ' + getActionData(nextId).label + '.', 'primary');
               makeActionAvailable(nextId);
@@ -177,7 +177,7 @@ const actionRegistry = {
           completionMax: 1,
           completionEffects: {
             1: function(actionId) {
-              logPopupCombo(getActionData(actionId).story.completion, 'success');
+              logPopupCombo(getActionData(actionId).story.completion, 'success', undefined, 'story');
               logPopupCombo('You have completed every task.', 'warning');
               makeActionUnavailable(actionId);
             }

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -318,6 +318,7 @@ function addLogEntry(text, id = generateUniqueId(), tag = 'default') {
     };
     gameState.gameLog.push(logEntry);
     updateLogUI();
+    updateStoryUI();
 }
 
 function updateLogUI() {
@@ -338,6 +339,22 @@ function updateLogUI() {
   // If the scrollbar was at the bottom, keep it at the bottom after the update
   if (isScrolledToBottom) {
     logTab.scrollTop = logTab.scrollHeight;
+  }
+}
+
+function updateStoryUI() {
+  const storyHeader = document.getElementById('book-header');
+  if (!storyHeader) return;
+
+  const isScrolledToBottom = storyHeader.scrollHeight - storyHeader.clientHeight <= storyHeader.scrollTop + 1;
+
+  storyHeader.textContent = '';
+  gameState.gameLog.filter(entry => entry.tag === 'story').forEach(entry => {
+    storyHeader.textContent += entry.text + '\n\n';
+  });
+
+  if (isScrolledToBottom) {
+    storyHeader.scrollTop = storyHeader.scrollHeight;
   }
 }
 
@@ -681,7 +698,7 @@ async function loadGame() {
 function initializeGame() {
   if (gameState.actionsAvailable.length === 0) {
     const opener = getLocationMeta('book1.hemlockForest.followWhisperingTrail').opener;
-    logPopupCombo(opener, 'info');
+    logPopupCombo(opener, 'info', undefined, 'story');
     gameState.actionsAvailable = ['book1.hemlockForest.followWhisperingTrail'];
   }
 

--- a/assets/scripts/ui.js
+++ b/assets/scripts/ui.js
@@ -8,6 +8,10 @@ function showBook() {
   if (typeof processActiveAndQueuedActions === 'function') { processActiveAndQueuedActions(); }
 }
 
+function showLog() {
+  openTab('log-tab');
+}
+
 function selectBook(bookId) {
   gameState.currentBook = bookId;
   updateBookButton();

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -385,6 +385,26 @@ body {
   border-radius: 2px;
 }
 
+.book-header,
+.book-footer {
+  flex-shrink: 0;
+  padding: 5px;
+}
+
+#actions-tab {
+  display: flex;
+  flex-direction: column;
+}
+
+#all-actions-container {
+  flex: 1;
+}
+
+.book-header {
+  overflow-y: auto;
+  white-space: pre-line;
+}
+
 .game-log {
   min-height:100%;
   padding: 5px;

--- a/index.html
+++ b/index.html
@@ -160,6 +160,9 @@
             <button class="menu-button menu-icon-button" id="book-button" onclick="showBook()">
               <span class="emoji">🐹</span><span class="label">Book</span>
             </button>
+            <button class="menu-button menu-icon-button d-md-none" id="log-button" onclick="showLog()">
+              <span class="emoji">📜</span><span class="label">Log</span>
+            </button>
             <button class="menu-button menu-icon-button d-none" id="artifacts-button" onclick="openArtifacts()">
               <span class="emoji">🗝️</span><span class="label">Artifacts</span>
             </button>
@@ -202,8 +205,10 @@
               <div id="timer-display"><span id="timer-icon">&#x23F1;</span> <span id="time-remaining">00:00</span></div>
             </div>
             <div class="row row-col-1 row-col-md-2 row-fix">
-              <div id="actions-tab" class="mobile-tab col d-md-block full-height scroll">
+              <div id="actions-tab" class="mobile-tab col d-md-block full-height">
+                <div id="book-header" class="book-header"></div>
                 <div id="all-actions-container" class="col full-height scroll"></div>
+                <div id="book-footer" class="book-footer"></div>
               </div>
               <div id="log-tab" class="mobile-tab col d-none d-md-block px-0 mx-3 full-height scroll">
                   <div id="game-log" class="game-log"></div>


### PR DESCRIPTION
## Summary
- Display story entries at top of book actions tab with new header and placeholder footer
- Add mobile Log tab and navigation button
- Tag action completion and opener text as story for header display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2673991588324ba93c63a3783948d