### PR TITLE
Add pocketwatch loop timer with progress arc and digital readout

### DIFF
--- a/assets/scripts/loop_timer.js
+++ b/assets/scripts/loop_timer.js
@@ -1,0 +1,40 @@
+(function(){
+  const timerEl = document.getElementById('loop-timer');
+  if(!timerEl) return;
+  const textEl = timerEl.querySelector('#loop-time-text');
+  const arcEl = timerEl.querySelector('.arc-progress');
+  const imgEl = timerEl.querySelector('.timer-bg');
+
+  if (imgEl && imgEl.dataset.localSrc) {
+    const test = new Image();
+    test.onload = () => { imgEl.src = imgEl.dataset.localSrc; };
+    test.src = imgEl.dataset.localSrc;
+  }
+
+  let TOTAL = 10 * 60 * 1000;
+  const WARN_MS = 60_000;
+  const CRIT_MS = 10_000;
+
+  window.initLoopTimer = function(totalMs){
+    if (Number.isFinite(totalMs) && totalMs > 0) TOTAL = totalMs;
+    timerEl.classList.remove('warn','critical');
+    if (arcEl) arcEl.style.strokeDashoffset = '0';
+    updateLoopTimer(TOTAL);
+  };
+
+  window.updateLoopTimer = function(remainingMs){
+    const rem = Math.max(0, Math.min(remainingMs, TOTAL));
+    const pct = (rem / TOTAL) * 100;
+    if (arcEl) arcEl.style.strokeDashoffset = String(100 - pct);
+    if (textEl) textEl.textContent = formatMMSS(rem);
+    timerEl.classList.toggle('warn', rem <= WARN_MS && rem > CRIT_MS);
+    timerEl.classList.toggle('critical', rem <= CRIT_MS && rem > 0);
+  };
+
+  function formatMMSS(ms){
+    const t = Math.max(0, Math.floor(ms/1000));
+    const m = Math.floor(t / 60);
+    const s = t % 60;
+    return `${String(m).padStart(2,'0')}:${String(s).padStart(2,'0')}`;
+  }
+})();

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -448,17 +448,12 @@ function updateTimerVisibility() {
   else container.classList.add('d-none');
 }
 
-function formatTime(sec) {
-  const m = Math.floor(sec / 60);
-  const s = Math.floor(sec % 60);
-  return String(m).padStart(2, '0') + ':' + String(s).padStart(2, '0');
-}
-
 function updateTimerUI() {
   updateTimerVisibility();
   if (!hasPocketWatch) return;
-  const el = document.getElementById('time-remaining');
-  if (el) el.innerText = formatTime(timeRemaining);
+  if (typeof updateLoopTimer === 'function') {
+    updateLoopTimer(timeRemaining * 1000);
+  }
 }
 
 function checkTimeWarnings() {
@@ -691,6 +686,9 @@ function initializeGame() {
 
   processPauseButton();
   processActiveAndQueuedActions();
+  if (typeof initLoopTimer === 'function') {
+    initLoopTimer(timeMax * 1000);
+  }
   updateTimerUI();
   refreshSkillsUI();
   recordStartingPermanentLevels();

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -140,23 +140,75 @@ body {
 
 /* LOOP TIMER */
 #timer-container {
-  flex: 0 0 auto;
-  padding: 5px;
-  border-radius: 5px;
-  background-color: rgba(255,255,255,0.6);
+  --timer-size: 300px;
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: var(--timer-size);
+  height: var(--timer-size);
 }
 
-#timer-display {
+.loop-timer {
+  position: relative;
+  width: 100%;
+  height: 100%;
   display: flex;
-  justify-content: center;
   align-items: center;
-  gap: 5px;
-  font-size: 1.2em;
-  font-family: monospace;
+  justify-content: center;
 }
 
-#timer-icon {
-  font-size: 1.2em;
+.timer-bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+.timer-arc {
+  position: absolute;
+  width: 72%;
+  height: 72%;
+  rotate: -90deg;
+}
+
+.arc-track {
+  fill: none;
+  stroke: rgba(255,255,255,.25);
+  stroke-width: 3.5;
+}
+
+.arc-progress {
+  fill: none;
+  stroke: #fff;
+  stroke-width: 3.5;
+  stroke-linecap: round;
+  stroke-dasharray: 100;
+  stroke-dashoffset: 0;
+  transition: stroke-dashoffset .35s linear;
+  filter: drop-shadow(0 0 4px rgba(255,255,255,.45));
+}
+
+.timer-readout {
+  position: relative;
+  font-weight: 700;
+  font-size: 1.5rem;
+  color: #fff;
+  text-shadow: 0 2px 4px rgba(0,0,0,.6);
+}
+
+.loop-timer.warn .arc-progress {
+  filter: drop-shadow(0 0 6px rgba(255,200,50,.9));
+}
+
+.loop-timer.critical {
+  animation: timerPulse 1s ease-in-out infinite;
+}
+
+@keyframes timerPulse {
+  0%,100% { transform: scale(1); }
+  50% { transform: scale(1.03); }
 }
 
 /* TABS MENU */

--- a/index.html
+++ b/index.html
@@ -198,8 +198,17 @@
           </div>
           <!-- Main View (Book). On by default. -->
           <div id="main-pane" class="content-pane col-12 full-height flex-vert">
-            <div id="timer-container" class="d-none align-self-end">
-              <div id="timer-display"><span id="timer-icon">&#x23F1;</span> <span id="time-remaining">00:00</span></div>
+            <div id="timer-container" class="d-none">
+              <div id="loop-timer" class="loop-timer" role="timer" aria-live="polite">
+                <img class="timer-bg" alt="Pocket watch"
+                     src="https://raw.githubusercontent.com/otakat/otakat.github.io/main/assets/images/PocketWatch.png"
+                     data-local-src="./assets/images/PocketWatch.png" />
+                <svg class="timer-arc" viewBox="0 0 44 44" aria-hidden="true">
+                  <circle class="arc-track" cx="22" cy="22" r="19.5"></circle>
+                  <circle class="arc-progress" cx="22" cy="22" r="19.5" pathLength="100"></circle>
+                </svg>
+                <div class="timer-readout"><span id="loop-time-text">00:00</span></div>
+              </div>
             </div>
             <div class="row row-col-1 row-col-md-2 row-fix">
               <div id="actions-tab" class="mobile-tab col d-md-block full-height scroll">
@@ -238,6 +247,7 @@
     <script src="./assets/scripts/clock.js" defer></script>
     <script src="./assets/scripts/start.js" defer></script>
     <script src="./assets/scripts/ui.js" defer></script>
+    <script src="./assets/scripts/loop_timer.js" defer></script>
 
 
 


### PR DESCRIPTION
## Summary
- Replace text timer with pocketwatch markup and SVG arc overlay
- Style timer for mobile layout with warn and critical states
- Provide loop timer API and integrate with existing game initialization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a26a5246488324acced9707f74ac72