### PR TITLE
Move stopwatch into action header

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -343,7 +343,7 @@ function updateLogUI() {
 }
 
 function updateStoryUI() {
-  const storyHeader = document.getElementById('book-header');
+  const storyHeader = document.getElementById('story-header-text');
   if (!storyHeader) return;
 
   const isScrolledToBottom =

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -140,12 +140,9 @@ body {
 
 /* LOOP TIMER */
 #timer-container {
-  --timer-size: 300px;
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  width: var(--timer-size);
-  height: var(--timer-size);
+  height: 100%;
+  aspect-ratio: 1 / 1;
+  position: relative;
 }
 
 .loop-timer {
@@ -468,9 +465,12 @@ body {
   overflow: hidden;
 }
 
-.book-header {
+#story-header-text {
   overflow-y: auto;
   white-space: normal;
+}
+
+.book-header {
   background: rgba(255,255,255,0.8);
   border: 1px solid #ccc;
   border-radius: 2px;

--- a/index.html
+++ b/index.html
@@ -201,21 +201,23 @@
           </div>
           <!-- Main View (Book). On by default. -->
           <div id="main-pane" class="content-pane col-12 full-height flex-vert">
-            <div id="timer-container" class="d-none">
-              <div id="loop-timer" class="loop-timer" role="timer" aria-live="polite">
-                <img class="timer-bg" alt="Pocket watch"
-                     src="https://raw.githubusercontent.com/otakat/otakat.github.io/main/assets/images/PocketWatch.png"
-                     data-local-src="./assets/images/PocketWatch.png" />
-                <svg class="timer-arc" viewBox="0 0 44 44" aria-hidden="true">
-                  <circle class="arc-track" cx="22" cy="22" r="19.5"></circle>
-                  <circle class="arc-progress" cx="22" cy="22" r="19.5" pathLength="100"></circle>
-                </svg>
-                <div class="timer-readout"><span id="loop-time-text">00:00</span></div>
-              </div>
-            </div>
             <div class="row row-col-1 row-col-md-2 row-fix">
               <div id="actions-tab" class="mobile-tab col d-md-block full-height">
-                <div id="book-header" class="book-header"></div>
+                <div id="book-header" class="book-header d-flex align-items-center">
+                  <div id="story-header-text" class="flex-grow-1 overflow-auto"></div>
+                  <div id="timer-container" class="d-none h-100 ms-2 flex-shrink-0">
+                    <div id="loop-timer" class="loop-timer" role="timer" aria-live="polite">
+                      <img class="timer-bg" alt="Pocket watch"
+                           src="https://raw.githubusercontent.com/otakat/otakat.github.io/main/assets/images/PocketWatch.png"
+                           data-local-src="./assets/images/PocketWatch.png" />
+                      <svg class="timer-arc" viewBox="0 0 44 44" aria-hidden="true">
+                        <circle class="arc-track" cx="22" cy="22" r="19.5"></circle>
+                        <circle class="arc-progress" cx="22" cy="22" r="19.5" pathLength="100"></circle>
+                      </svg>
+                      <div class="timer-readout"><span id="loop-time-text">00:00</span></div>
+                    </div>
+                  </div>
+                </div>
                 <div id="all-actions-container"></div>
                 <div id="book-footer" class="book-footer">
                   <img src="./assets/images/footer-placeholder.svg" alt="Placeholder graphic" class="footer-placeholder">


### PR DESCRIPTION
## Summary
- Integrate the stopwatch into the action header alongside the story log, using Bootstrap flex utilities for alignment.
- Adjust stopwatch styles to fill the header height and maintain square aspect ratio.
- Update story UI script to target the new story header container without removing the stopwatch element.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a279e9da60832494f5fe69ce1d3949