### PR TITLE
Remove redundant action start/stop controls

### DIFF
--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -23,23 +23,11 @@ class GameAction {
               progressContainer: this.container.querySelector('.action-progress-container'),
               progressText: this.container.querySelector('.action-progress-text'),
               progressBarCurrent: this.container.querySelector('.action-progress-bar-current'),
-              progressBarMastery: this.container.querySelector('.action-progress-bar-mastery'),
-              buttonActivate: this.container.querySelector('#start-button'),
-              buttonStop: this.container.querySelector('#stop-button')
-                          
+              progressBarMastery: this.container.querySelector('.action-progress-bar-mastery')
+
                         }
       // Allow clicking anywhere on the action body to toggle the action
       this.container.addEventListener('click', () => toggleAction(id));
-
-      // Add button effects
-      this.elements.buttonActivate.addEventListener('click', (event) => {
-        event.stopPropagation();
-        activateAction(id);
-      });
-      this.elements.buttonStop.addEventListener('click', (event) => {
-        event.stopPropagation();
-        fullyDeactivateAction(id);
-      });
 
       this.calculateTimeStart();
       this.update();
@@ -195,11 +183,6 @@ function createNewAction(id) {
   container.innerHTML = `
     <div class="action-header">
       <span class="action-label" data-tippy-content="Action Label">${label}</span>
-      <span class="action-button-container">
-
-        <button id="start-button" class="action-button" data-tippy-content="Start">⏵</button>
-        <button id="stop-button" class="action-button stop-button" data-tippy-content="Stop">X</button>
-      </span>
     </div>
     <div class="action-progress-container">
       <div class="action-progress-text">0% Mastery + 0% Current</div>

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -331,26 +331,6 @@ body {
           font-size: 1.2em;
         }
 
-        .action-button-container {
-          flex: 0 0 auto;
-          display: flex;
-          flex-flow: row wrap;
-          justify-content: space-between;
-          gap: 2px;
-        }
-
-          .action-button {
-            flex: 0 0 25px;
-            height: 25px;
-            width: 25px;
-            background: #eee;
-            border: 1px solid #555;
-            border-radius: 4px;
-            padding: 1px;
-            cursor: pointer;
-            font-size: 1em;
-          }
-
       .action-progress-container {
         width: 100%;
         background-color: #555;


### PR DESCRIPTION
## Summary
- Drop dedicated start/stop buttons from actions; click anywhere to toggle
- Remove unused button styles for cleaner UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a291dde40083248a7c326767a51173