### PR TITLE
feat: add item inventory system

### DIFF
--- a/assets/scripts/items.js
+++ b/assets/scripts/items.js
@@ -1,0 +1,169 @@
+const itemData = {
+  healing_potion: {
+    label: 'Healing Potion',
+    emoji: '🧪',
+    description: 'Restores 10 seconds of loop time.',
+    type: 'usable',
+    effect() {
+      setTimeRemaining(gameState.timeRemaining + 10);
+      logPopupCombo('You feel time wind back a little.', 'success');
+    }
+  },
+  smoke_bomb: {
+    label: 'Smoke Bomb',
+    emoji: '💣',
+    description: 'Creates a smokescreen to escape.',
+    type: 'usable',
+    effect() {
+      logPopupCombo('Poof! The smoke bomb fizzles harmlessly.', 'secondary');
+    }
+  },
+  magic_lantern: {
+    label: 'Magic Lantern',
+    emoji: '🏮',
+    description: 'Reveals hidden paths for a moment.',
+    type: 'usable',
+    effect() {
+      logPopupCombo('The lantern glows, but nothing happens…', 'info');
+    }
+  },
+  fairy_dust: {
+    label: 'Fairy Dust',
+    emoji: '✨',
+    description: 'A pinch might hasten your step.',
+    type: 'usable',
+    effect() {
+      logPopupCombo('You sparkle briefly.', 'info');
+    }
+  },
+  throwing_stone: {
+    label: 'Throwing Stone',
+    emoji: '🪨',
+    description: 'Distracts small foes when tossed.',
+    type: 'usable',
+    effect() {
+      logPopupCombo('You toss the stone. It skitters away.', 'info');
+    }
+  },
+  bread: {
+    label: 'Bread',
+    emoji: '🍞',
+    description: 'A simple snack to keep you going.',
+    type: 'usable',
+    effect() {
+      logPopupCombo('Tasty! But you\'re still hungry.', 'secondary');
+    }
+  },
+  lucky_clover: {
+    label: 'Lucky Clover',
+    emoji: '🍀',
+    description: 'Passively increases your luck.',
+    type: 'static'
+  },
+  hourglass_charm: {
+    label: 'Hourglass Charm',
+    emoji: '⏳',
+    description: 'Adds 5 seconds to your loop time.',
+    type: 'static',
+    apply() {
+      setTimeRemaining(gameState.timeRemaining + 5);
+    }
+  },
+  silver_feather: {
+    label: 'Silver Feather',
+    emoji: '🪶',
+    description: 'Makes your steps lighter.',
+    type: 'static'
+  },
+  library_card: {
+    label: 'Library Card',
+    emoji: '🪪',
+    description: 'Grants access to certain stacks.',
+    type: 'static'
+  },
+  mystic_orb: {
+    label: 'Mystic Orb',
+    emoji: '🔮',
+    description: 'Whispers of distant futures surround it.',
+    type: 'static'
+  },
+  ancient_map: {
+    label: 'Ancient Map',
+    emoji: '🗺️',
+    description: 'Shows paths long forgotten.',
+    type: 'static'
+  }
+};
+
+function addItem(id, qty = 1) {
+  const data = itemData[id];
+  if (!data) return;
+  if (!gameState.inventory[id]) {
+    gameState.inventory[id] = 0;
+  }
+  gameState.inventory[id] += Number(qty);
+  if (data.type === 'static' && typeof data.apply === 'function') {
+    data.apply();
+  }
+  refreshInventoryUI();
+}
+
+function useItem(id) {
+  const data = itemData[id];
+  if (!data || data.type !== 'usable') return;
+  const count = gameState.inventory[id] || 0;
+  if (count <= 0) return;
+  if (typeof data.effect === 'function') {
+    data.effect();
+  }
+  gameState.inventory[id] = count - 1;
+  if (gameState.inventory[id] <= 0) {
+    delete gameState.inventory[id];
+  }
+  refreshInventoryUI();
+}
+
+function refreshInventoryUI() {
+  const usable = document.getElementById('usable-items');
+  const statics = document.getElementById('static-items');
+  if (!usable || !statics) return;
+  usable.innerHTML = '';
+  statics.innerHTML = '';
+  const inv = gameState.inventory || {};
+  Object.keys(inv).forEach(id => {
+    const count = inv[id];
+    if (count <= 0) return;
+    const data = itemData[id];
+    if (!data) return;
+    const el = document.createElement('div');
+    el.className = 'item-icon';
+    el.textContent = data.emoji;
+    if (data.type === 'usable') {
+      el.classList.add('usable');
+      el.addEventListener('click', () => useItem(id));
+    }
+    if (count > 1) {
+      const bubble = document.createElement('div');
+      bubble.className = 'item-count';
+      bubble.textContent = count;
+      el.appendChild(bubble);
+    }
+    const tip = document.createElement('div');
+    tip.innerHTML = `<strong>${data.label}</strong><div class="item-desc">${data.description}</div>`;
+    if (data.type === 'usable') {
+      const btn = document.createElement('button');
+      btn.className = 'btn btn-primary btn-sm mt-1';
+      btn.textContent = 'Use';
+      btn.addEventListener('click', (e) => { e.stopPropagation(); useItem(id); });
+      tip.appendChild(btn);
+    }
+    tippy(el, { content: tip, allowHTML: true, interactive: true, trigger: 'mouseenter focus', touch: ['hold', 500] });
+    if (data.type === 'usable') {
+      usable.appendChild(el);
+    } else {
+      statics.appendChild(el);
+    }
+  });
+}
+
+

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -722,6 +722,28 @@ function initializeGame() {
   Object.keys(gameState.artifacts).forEach(id => {
     if (gameState.artifacts[id]) {applyArtifactEffects(id);}
   });
+  Object.keys(gameState.inventory || {}).forEach(id => {
+    const data = itemData[id];
+    if (data && data.type === 'static' && typeof data.apply === 'function') {
+      data.apply();
+    }
+  });
+  if (Object.keys(gameState.inventory || {}).length === 0) {
+    addItem('healing_potion', 3);
+    addItem('smoke_bomb', 2);
+    addItem('magic_lantern', 1);
+    addItem('fairy_dust', 1);
+    addItem('throwing_stone', 4);
+    addItem('bread', 1);
+    addItem('lucky_clover', 1);
+    addItem('hourglass_charm', 1);
+    addItem('silver_feather', 1);
+    addItem('library_card', 1);
+    addItem('mystic_orb', 1);
+    addItem('ancient_map', 1);
+  } else {
+    refreshInventoryUI();
+  }
   updateMenuButtons();
 }
 

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -440,22 +440,60 @@ body {
   flex-shrink: 0;
   padding: 5px;
   height: 80px;
-}
-
-.book-footer {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
-  text-align: center;
   background: rgba(255,255,255,0.8);
   border: 1px solid #ccc;
   border-radius: 2px;
+  overflow: hidden;
 }
 
-.footer-placeholder {
-  max-width: 100%;
-  max-height: 100%;
-  height: auto;
+.inventory-bar {
+  display: flex;
+  flex: 1 1 auto;
+  overflow-x: auto;
+  gap: 8px;
+  -webkit-overflow-scrolling: touch;
+}
+
+.item-group {
+  display: flex;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.item-icon {
+  position: relative;
+  width: 48px;
+  height: 48px;
+  flex: 0 0 auto;
+  font-size: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: rgba(255,255,255,0.9);
+  cursor: pointer;
+}
+
+.item-icon.usable {
+  box-shadow: 0 0 8px rgba(100,149,237,0.7);
+}
+
+.item-count {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  background: #dc3545;
+  color: #fff;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 3px;
+  border-radius: 8px;
+  font-size: 12px;
+  line-height: 16px;
+  text-align: center;
 }
 
 #actions-tab {

--- a/index.html
+++ b/index.html
@@ -220,7 +220,10 @@
                 </div>
                 <div id="all-actions-container"></div>
                 <div id="book-footer" class="book-footer">
-                  <img src="./assets/images/footer-placeholder.svg" alt="Placeholder graphic" class="footer-placeholder">
+                  <div id="inventory-bar" class="inventory-bar">
+                    <div id="usable-items" class="item-group"></div>
+                    <div id="static-items" class="item-group"></div>
+                  </div>
                 </div>
               </div>
               <div id="log-tab" class="mobile-tab col d-none d-md-block px-0 mx-3 full-height scroll">
@@ -254,6 +257,7 @@
       <script src="./assets/scripts/action_runner.js" defer></script>
       <script src="./assets/scripts/action_functions.js" defer></script>
     <script src="./assets/scripts/script.js" defer></script>
+    <script src="./assets/scripts/items.js" defer></script>
     <script src="./assets/scripts/clock.js" defer></script>
     <script src="./assets/scripts/start.js" defer></script>
     <script src="./assets/scripts/ui.js" defer></script>


### PR DESCRIPTION
## Summary
- implement scrollable item bar in book footer with emoji placeholders
- add item definitions, tooltips, use button, and stack counts
- initialize demo items and apply passive item effects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2942f4b4c8324acee54c0bb50a3db