### PR TITLE
Fix Bootstrap grid classes for main view

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
           </div>
           <!-- Main View (Book). On by default. -->
           <div id="main-pane" class="content-pane col-12 full-height flex-vert">
-            <div class="row row-col-1 row-col-md-2 row-fix">
+            <div class="row row-cols-1 row-cols-md-2 row-fix">
               <div id="actions-tab" class="mobile-tab col d-md-block full-height">
                 <div id="book-header" class="book-header d-flex align-items-center">
                   <div id="story-header-text" class="flex-grow-1 overflow-auto"></div>


### PR DESCRIPTION
## Summary
- Use `row-cols-1`/`row-cols-md-2` to ensure responsive grid

## Testing
- `node - <<'NODE'
const puppeteer=require('puppeteer');(async()=>{const b=await puppeteer.launch({args:['--no-sandbox']});const p=await b.newPage();await p.setViewport({width:375,height:800});await p.goto('file:///workspace/otakat.github.io/index.html');await p.addStyleTag({path:'/tmp/bootstrap.min.css'});const mobile=await p.evaluate(()=>({actionsWidth:Math.round(document.querySelector('#actions-tab').getBoundingClientRect().width),logDisplay:window.getComputedStyle(document.querySelector('#log-tab')).display,logWidth:Math.round(document.querySelector('#log-tab').getBoundingClientRect().width)}));await p.setViewport({width:1024,height:800});await p.goto('file:///workspace/otakat.github.io/index.html');await p.addStyleTag({path:'/tmp/bootstrap.min.css'});const desktop=await p.evaluate(()=>({actionsWidth:Math.round(document.querySelector('#actions-tab').getBoundingClientRect().width),logWidth:Math.round(document.querySelector('#log-tab').getBoundingClientRect().width)}));console.log({mobile,desktop});await b.close();})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a2946aba708324b601dc1bbfc38db4