### PR TITLE
Use Bootstrap buttons for menu

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -545,7 +545,7 @@ function showResetPopup(){
   // Halt clock and display results
   gameOver = true;
   addPauseState(pauseStates.MODAL);
-  document.querySelectorAll('button:not(.menu-button)').forEach(btn => btn.disabled = true);
+  document.querySelectorAll('button').forEach(btn => btn.disabled = true);
   const restartBtn = document.querySelector('#resetModal button');
   if (restartBtn) {restartBtn.disabled = false;}
 
@@ -573,7 +573,7 @@ function showResetPopup(){
 function restartGame(){
   const modal = bootstrap.Modal.getInstance(document.getElementById('resetModal'));
   if (modal) {modal.hide();}
-  document.querySelectorAll('button:not(.menu-button)').forEach(btn => btn.disabled = false);
+  document.querySelectorAll('button').forEach(btn => btn.disabled = false);
 
   timeRemaining = timeMax;
   gameState.timeRemaining = timeRemaining;

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -98,41 +98,6 @@ body {
   }
 
 /* MENU */
-.menu-button {
-    width:auto;
-    height: 40px;
-    font-size: 0.8em;
-    flex: 0 1 auto;
-    line-height: 1.1;
-    margin: 1px;
-    padding: 3px 10px;
-    cursor: pointer;
-  }
-
-.menu-icon-button {
-  width: 60px;
-  height: 60px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  font-size: 1.5rem;
-  line-height: 1;
-  background-color: rgba(255,255,255,0.8);
-  border: 1px solid #ccc;
-  border-radius: 8px;
-  box-sizing: border-box;
-  padding: 4px;
-}
-
-.menu-icon-button .label {
-  font-size: 0.6rem;
-  margin-top: 2px;
-}
-
-.system-menu, .game-menu {
-  gap: 5px;
-}
 
 .library-book-option.selected {
   border: 2px solid blue;

--- a/index.html
+++ b/index.html
@@ -31,18 +31,18 @@
         </div>
 
         <!-- System menu row -->
-        <div class="row px-3 system-menu">
-            <button class="menu-button menu-icon-button" onclick="openTab('settings-pane')">
-              <span class="emoji">⚙️</span><span class="label">Settings</span>
+        <div class="row g-1 px-3 system-menu">
+            <button class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1" onclick="openTab('settings-pane')">
+              <span class="emoji fs-4">⚙️</span><span class="label small">Settings</span>
             </button>
-            <button class="menu-button menu-icon-button" onclick="saveGame(true).catch(console.error)" data-tippy-content="Store progress">
-              <span class="emoji">💾</span><span class="label">Save</span>
+            <button class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1" onclick="saveGame(true).catch(console.error)" data-tippy-content="Store progress">
+              <span class="emoji fs-4">💾</span><span class="label small">Save</span>
             </button>
-            <button class="menu-button menu-icon-button" id="pause-button" onclick="buttonPause()" data-tippy-content="Toggle clock pause">
-              <span class="emoji">⏸️</span><span class="label">Pause</span>
+            <button class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1" id="pause-button" onclick="buttonPause()" data-tippy-content="Toggle clock pause">
+              <span class="emoji fs-4">⏸️</span><span class="label small">Pause</span>
             </button>
-            <button class="menu-button menu-icon-button" id="main-button" onclick="showBook()" data-tippy-content="Return to main view">
-              <span class="emoji">🏠</span><span class="label">Main</span>
+            <button class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1" id="main-button" onclick="showBook()" data-tippy-content="Return to main view">
+              <span class="emoji fs-4">🏠</span><span class="label small">Main</span>
             </button>
         </div>
 
@@ -153,21 +153,21 @@
           </div>
         </div>
         <!-- Game menu row -->
-        <div class="row px-3 game-menu">
-            <button class="menu-button menu-icon-button d-none" id="library-button" onclick="showLibrary()">
-              <span class="emoji">📚</span><span class="label">Library</span>
+        <div class="row g-1 px-3 game-menu">
+            <button class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1 d-none" id="library-button" onclick="showLibrary()">
+              <span class="emoji fs-4">📚</span><span class="label small">Library</span>
             </button>
-            <button class="menu-button menu-icon-button" id="book-button" onclick="showBook()">
-              <span class="emoji">🐹</span><span class="label">Book</span>
+            <button class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1" id="book-button" onclick="showBook()">
+              <span class="emoji fs-4">🐹</span><span class="label small">Book</span>
             </button>
-            <button class="menu-button menu-icon-button d-md-none" id="log-button" onclick="showLog()">
-              <span class="emoji">📜</span><span class="label">Log</span>
+            <button class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1 d-md-none" id="log-button" onclick="showLog()">
+              <span class="emoji fs-4">📜</span><span class="label small">Log</span>
             </button>
-            <button class="menu-button menu-icon-button d-none" id="artifacts-button" onclick="openArtifacts()">
-              <span class="emoji">🗝️</span><span class="label">Artifacts</span>
+            <button class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1 d-none" id="artifacts-button" onclick="openArtifacts()">
+              <span class="emoji fs-4">🗝️</span><span class="label small">Artifacts</span>
             </button>
-            <button class="menu-button menu-icon-button d-none" id="skills-button" onclick="openSkills()">
-              <span class="emoji">🧠</span><span class="label">Skills</span>
+            <button class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1 d-none" id="skills-button" onclick="openSkills()">
+              <span class="emoji fs-4">🧠</span><span class="label small">Skills</span>
             </button>
         </div>
         <!-- Row for everything else -->
@@ -194,8 +194,8 @@
             <h2>📚 Library</h2>
             <p>Select a book to begin. 🐹</p>
             <div class="d-flex justify-content-center gap-2 mt-3" id="library-book-list">
-              <button id="book1-option" class="menu-button menu-icon-button library-book-option" onclick="selectBook('book1')">
-                <span class="emoji">🐹</span><span class="label">Book 1</span>
+              <button id="book1-option" class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1 library-book-option" onclick="selectBook('book1')">
+                <span class="emoji fs-4">🐹</span><span class="label small">Book 1</span>
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Replace custom menu buttons with Bootstrap `btn btn-light` and flex utilities
- Drop obsolete `.menu-button`/`.menu-icon-button` styles
- Simplify reset logic to disable/enable all buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a29498d1948324a5f2b5ffeae3ec54