### PR TITLE
Fix action container height to keep item bar at bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
             </button>
         </div>
         <!-- Row for everything else -->
-        <div class="row row-fix">
+        <div class="row flex-fill" style="min-height: 0;">
 
           <!-- Settings. Off by default. -->
             <div id="settings-pane" class="content-pane d-none col-12 h-100">


### PR DESCRIPTION
## Summary
- Replace custom `.row-fix` helper with Bootstrap's `flex-fill` utility so the main row expands and the item bar stays anchored.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a29dfc73e483248e5934d91565b923