### PR TITLE
Default to mobile layout and adjust viewport height

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -18,15 +18,17 @@
 
 /* BODY */
 html {
-	height: 100vh;
-	scroll-behavior: smooth;
+        height: 100vh;
+        height: 100dvh;
+        scroll-behavior: smooth;
   overflow: hidden;
 }
 
 body {
   font-family: Arial, sans-serif;
   height: 100vh;
-	font-size: 16px;
+  height: 100dvh;
+        font-size: 16px;
   line-height: 1.5;
   overflow: hidden;
   background-color: #444;
@@ -35,8 +37,10 @@ body {
 .game-wrapper {
   background: url('../images/book.png');
   background-repeat: no-repeat;
-  background-size: 100% 100vh; /* Always stretched to screen height */
+  background-size: 100% 100vh;
+  background-size: 100% 100dvh; /* Always stretched to screen height */
   height: 100vh; /* Forces content to full screen height */
+  height: 100dvh;
   display: flex;
   flex-flow: column nowrap;
   justify-content: flex-start;
@@ -432,7 +436,8 @@ body {
 /* MOBILE-SPECIFIC STYLE */
 @media only screen and (max-width: 768px) {
   .game-wrapper {
-    background-size: 200% 100vh; /* Only right book-page in mobile */
+    background-size: 200% 100vh;
+    background-size: 200% 100dvh; /* Only right book-page in mobile */
     background-position: top right;
   }
 }

--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@
             <button class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1" id="book-button" onclick="showBook()">
               <span class="emoji fs-4">🐹</span><span class="label small">Book</span>
             </button>
-            <button class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1 d-md-none" id="log-button" onclick="showLog()">
+            <button class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1" id="log-button" onclick="showLog()">
               <span class="emoji fs-4">📜</span><span class="label small">Log</span>
             </button>
             <button class="btn btn-light d-flex flex-column align-items-center justify-content-center p-1 gap-1 d-none" id="artifacts-button" onclick="openArtifacts()">
@@ -200,8 +200,8 @@
           </div>
           <!-- Main View (Book). On by default. -->
             <div id="main-pane" class="content-pane col-12 h-100 d-flex flex-column">
-              <div class="row row-col-1 row-col-md-2 flex-fill">
-                <div id="actions-tab" class="mobile-tab col d-md-block h-100">
+              <div class="row flex-fill">
+                <div id="actions-tab" class="mobile-tab col-12 h-100">
                 <div id="book-header" class="book-header d-flex align-items-center">
                   <div id="story-header-text" class="flex-grow-1 overflow-auto"></div>
                   <div id="timer-container" class="d-none h-100 ms-2 flex-shrink-0">
@@ -225,7 +225,7 @@
                   </div>
                 </div>
               </div>
-                <div id="log-tab" class="mobile-tab col d-none d-md-block px-0 mx-3 h-100 overflow-scroll">
+                <div id="log-tab" class="mobile-tab col-12 d-none px-0 h-100 overflow-scroll">
                   <div id="game-log" class="game-log"></div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- remove desktop-specific layout classes so the mobile UI is always used
- ensure `html`, `body`, and `.game-wrapper` use dynamic viewport height to keep the item bar visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a22cf3988324b91745c0a46830ac