### PR TITLE
Remove action exhaustion popup

### DIFF
--- a/assets/scripts/action_registry.js
+++ b/assets/scripts/action_registry.js
@@ -33,7 +33,6 @@ const default_action = {
         logPopupCombo('You completed ' + getActionData(actionId).label + '.', 'action_complete');
       },
       last: function (actionId) {
-        logPopupCombo('You cannot perform ' + getActionData(actionId).label + ' anymore.', 'action_failure');
         makeActionUnavailable(actionId);
       }
     }


### PR DESCRIPTION
## Summary
- Silence the "You cannot perform X anymore" popup when an action reaches its completion limit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b5cfa0b08324a1f6c2a6d9d5ff32