### PR TITLE
Enable scrolling within action container and footer

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -251,7 +251,7 @@ body {
   /* ACTIONS */
   #all-actions-container {
     display: flex;
-    flex: 1 1 auto;
+    flex: 1 1 0%;
     flex-flow: column nowrap;
     justify-content: flex-start;
     gap: 5px;

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -255,7 +255,11 @@ body {
     flex-flow: column nowrap;
     justify-content: flex-start;
     gap: 5px;
-    overflow-y: auto;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+    scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
     min-height: 0;
   }
 

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -256,6 +256,7 @@ body {
     justify-content: flex-start;
     gap: 5px;
     overflow-y: auto;
+    min-height: 0;
   }
 
     .action-container {
@@ -379,7 +380,15 @@ body {
   background: rgba(255,255,255,0.8);
   border: 1px solid #ccc;
   border-radius: 2px;
+}
+
+.book-header {
   overflow: hidden;
+}
+
+.book-footer {
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .inventory-bar {
@@ -433,12 +442,13 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 0;
   overflow: hidden;
 }
 
 #story-header-text {
   height: 100%;
-  overflow-y: auto;
+  overflow: hidden;
   white-space: normal;
   font-size: 0.9rem;
   line-height: 1.2;


### PR DESCRIPTION
## Summary
- Allow the main action list to flex and scroll within the tab
- Prevent header text from scrolling and keep footer horizontally scrollable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b8358f548324abdac27ad25b8f19