### PR TITLE
Limit fixed-step iterations in clock

### DIFF
--- a/assets/scripts/clock.js
+++ b/assets/scripts/clock.js
@@ -56,9 +56,19 @@ class GlobalClock {
     // Fixed-step logic accumulator
     const stepMs = 1000 / gameState.globalParameters.logicHz;
     this.accumulator += gameDelta;
-    while (this.accumulator >= stepMs) {
+    const MAX_STEPS = 5;
+    let steps = 0;
+    while (this.accumulator >= stepMs && steps < MAX_STEPS) {
       eventBus.emit('tick-fixed', { stepMs });
       this.accumulator -= stepMs;
+      steps += 1;
+    }
+    if (this.accumulator >= stepMs && steps >= MAX_STEPS) {
+      if (gameState.debugMode) {
+        console.warn(
+          `Clamped fixed-step iterations at ${MAX_STEPS}, leftover ${this.accumulator.toFixed(2)}ms`
+        );
+      }
     }
 
     // Variable-step game tick


### PR DESCRIPTION
## Summary
- Prevent runaway fixed-step loops by clamping to 5 iterations per beat
- Warn in debug mode when clamping leaves leftover time

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ba72a36c832488ede0bd8d87b7b2