### PR TITLE
Decouple action logic from rendering

### DIFF
--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -30,7 +30,7 @@ class GameAction {
       this.container.addEventListener('click', () => toggleAction(id));
 
       this.calculateTimeStart();
-      this.update();
+      this.render();
   }
 
         get isAvailable() {
@@ -88,7 +88,7 @@ class GameAction {
                 if (gameState.debugMode) console.log(`Action ${this.id} stopped`);
         }
 
-  update(timeChange = 0) {
+  step(timeChange = 0) {
     if (typeof this.progress.timeCurrent !== 'number' || isNaN(this.progress.timeCurrent)) {
       this.progress.timeCurrent = 0;
     }
@@ -103,15 +103,17 @@ class GameAction {
     runActionTick(this, timeChange);
 
     this.calculateTimeStart();
+  }
 
+  render() {
     const currentPercentage = (this.progress.timeCurrent / this.data.length) * 100;
     const masteryPercentage = (this.progress.timeStart / this.data.length) * 100;
-    const label = masteryPercentage.toFixed(1) + '% Mastery + ' + (currentPercentage - masteryPercentage).toFixed(1) + '% Current';
+    const label =
+      masteryPercentage.toFixed(1) + '% Mastery + ' + (currentPercentage - masteryPercentage).toFixed(1) + '% Current';
 
     this.elements.progressBarCurrent.style.width = currentPercentage + '%';
     this.elements.progressText.innerText = label;
     this.elements.progressBarMastery.style.width = masteryPercentage + '%';
-
   }
 
     finish() {
@@ -119,7 +121,6 @@ class GameAction {
       if (gameState.debugMode) console.log(`Action ${this.id} finished`);
       this.calculateTimeStart();
       this.progress.timeCurrent = this.progress.timeStart;
-      this.update();
       deactivateAction(this.id);
 
     this.data.completionEffects.each(this.id);

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -495,15 +495,20 @@ function runGameTick(stepMs) {
   if (!isGamePaused()) {
     timeTotal += stepMs;
     gameState.actionsActive.forEach(actionId => {
-      actionsConstructed[actionId].update(stepMs);
+      actionsConstructed[actionId].step(stepMs);
     });
     processScheduledEvents();
-    processActiveAndQueuedActions();
   }
 }
 
 // Listen for each fixed clock beat
 eventBus.on('tick-fixed', ({ stepMs }) => runGameTick(stepMs));
+
+// Render cycle
+eventBus.on('heartbeat', () => {
+  Object.values(actionsConstructed).forEach(action => action.render());
+  processActiveAndQueuedActions();
+});
 
 function buttonPause() {
   if (gameState.pausedReasons.includes(pauseStates.MANUAL)) {


### PR DESCRIPTION
## Summary
- Split `GameAction.update` into new `step` and `render` methods for logic vs. DOM updates.
- Call `step` each logic tick and batch `render` during the heartbeat render cycle.

## Testing
- `node --check assets/scripts/action_functions.js`
- `node --check assets/scripts/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2ba747b0c832486eb6aeb7615b6d5