### PR TITLE
Batch time consumption and defer timer updates

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -547,14 +547,31 @@ function checkTimeWarnings() {
   }
 }
 
-function consumeTime(cost) {
-  const c = Number(cost) || 0;
-  timeRemaining -= c;
+let pendingTimeCost = 0;
+let refreshScheduled = false;
+
+function applyPendingTime() {
+  timeRemaining -= pendingTimeCost;
   if (timeRemaining < 0) timeRemaining = 0;
   gameState.timeRemaining = timeRemaining;
+  pendingTimeCost = 0;
+  refreshScheduled = false;
   checkTimeWarnings();
   gameState.timeWarnings = { ...timeWarnings };
   updateTimerUI();
+}
+
+function consumeTime(cost) {
+  const c = Number(cost) || 0;
+  pendingTimeCost += c;
+  if (!refreshScheduled) {
+    refreshScheduled = true;
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(applyPendingTime);
+    } else {
+      setTimeout(applyPendingTime, 50);
+    }
+  }
 }
 
 function openTab(tabId = 'None') {


### PR DESCRIPTION
## Summary
- Accumulate time costs and apply them in a single refresh
- Defer timer updates with `requestAnimationFrame` or a timed fallback
- Invoke warning checks and UI redraw once per batch

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ba74e6088324b6a1299db99dccf5