### PR TITLE
feat: constrain main pane flex behavior

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -438,6 +438,11 @@ body {
   text-align: center;
 }
 
+#main-pane {
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
 #actions-tab {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- keep the actions area constrained by flexing `#main-pane`

## Testing
- `node verify-layout.js` *(failed: footer not visible; actions tab remained within parent)*

------
https://chatgpt.com/codex/tasks/task_e_68a2be01dac8832487ee5fcb891c4d83