### PR TITLE
Fix overlay removal when closing skills modal

### DIFF
--- a/assets/scripts/ui.js
+++ b/assets/scripts/ui.js
@@ -42,7 +42,15 @@ function updateLibrarySelection() {
 
 function openSkills() {
   if (typeof refreshSkillsUI === 'function') { refreshSkillsUI(); }
-  const modal = new bootstrap.Modal(document.getElementById('skillsModal'));
+  const modalEl = document.getElementById('skillsModal');
+  const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+
+  // Ensure any backdrop is cleaned up when the modal closes so gameplay can resume
+  modalEl.addEventListener('hidden.bs.modal', () => {
+    document.querySelectorAll('.modal-backdrop').forEach(b => b.remove());
+    deletePauseState?.(pauseStates?.MODAL);
+  }, { once: true });
+
   modal.show();
 }
 


### PR DESCRIPTION
## Summary
- Ensure closing the skills modal cleans up the backdrop and unpauses gameplay

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f9c0428883248e85f480c98f9c77