### PR TITLE
fix: prevent closing reset modal

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -638,7 +638,11 @@ function showResetPopup(){
     summaryList.appendChild(li);
   });
 
-  const modal = new bootstrap.Modal(document.getElementById('resetModal'));
+  // Prevent closing the reset modal by clicking outside or pressing Escape
+  const modal = new bootstrap.Modal(
+    document.getElementById('resetModal'),
+    { backdrop: 'static', keyboard: false }
+  );
   modal.show();
   if (!gameState.artifacts?.skillbook) {unlockArtifact('skillbook');}
 }

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
 				</div>
 
 				<div id="popup-container"></div>
-				<div class="modal fade" id="resetModal" tabindex="-1" aria-labelledby="resetModalLabel" aria-hidden="true">
+                                <div class="modal fade" id="resetModal" tabindex="-1" aria-labelledby="resetModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
 					<div class="modal-dialog modal-dialog-centered">
 						<div class="modal-content text-center">
 							<div class="modal-header">


### PR DESCRIPTION
## Summary
- make loop reset modal persistent until restart is clicked
- add static backdrop/keyboard options to reset modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fa7b3c808324a472863e4b414472