### PR TITLE
Defer action refresh to heartbeat

### DIFF
--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -9,6 +9,8 @@ const skillEmojis = {
 };
 globalThis.skillEmojis = skillEmojis;
 
+let pendingActionRefresh = false;
+
 // THE ACTION CLASS
 class GameAction {
   constructor(id) {
@@ -180,8 +182,9 @@ class GameAction {
       this.data.completionEffects.last(this.id);
     }
 
-    if (gameState.debugMode) console.log(this.id);
-  }
+      if (gameState.debugMode) console.log(this.id);
+      pendingActionRefresh = true;
+    }
 
   initializeActionProgress() {
 		let progress = gameState.actionsProgress;
@@ -255,7 +258,7 @@ function createNewAction(id) {
 
   actionsConstructed[id] = new GameAction(id);
   updateActionSkillIcons();
-  processActiveAndQueuedActions();
+  pendingActionRefresh = true;
 }
 
 // Access a constructed GameAction safely
@@ -276,10 +279,10 @@ function removeAction(actionId) {
     }
 
     // Remove from gameState and arrays
-    delete actionsConstructed[actionId];
-    gameState.actionsAvailable = gameState.actionsAvailable.filter(id => id !== actionId);
-    gameState.actionsActive = gameState.actionsActive.filter(id => id !== actionId);
-    processActiveAndQueuedActions();
+  delete actionsConstructed[actionId];
+  gameState.actionsAvailable = gameState.actionsAvailable.filter(id => id !== actionId);
+  gameState.actionsActive = gameState.actionsActive.filter(id => id !== actionId);
+  pendingActionRefresh = true;
 
     // Any additional cleanup...
 }
@@ -297,7 +300,7 @@ function makeActionAvailable(actionId) {
       actionsConstructed[actionId].container.style.display = 'none';
     }
   }
-  processActiveAndQueuedActions();
+  pendingActionRefresh = true;
 }
 
 function makeActionUnavailable(actionId) {
@@ -309,6 +312,7 @@ function makeActionUnavailable(actionId) {
     // Optionally hide:
     // actionsConstructed[actionId].container.style.display = 'none';
   }
+  pendingActionRefresh = true;
 }
 
 function toggleAction(actionId) {
@@ -329,7 +333,7 @@ function activateAction(actionId) {
   if (gameState.actionsActive.includes(actionId)) {
     // Ensure listener is on, just in case
     a.start();
-    processActiveAndQueuedActions();
+    pendingActionRefresh = true;
     return true;
   }
 
@@ -343,7 +347,7 @@ function activateAction(actionId) {
   }
 
   gameState.actionsActive.unshift(actionId);
-  processActiveAndQueuedActions();
+  pendingActionRefresh = true;
   return true;
 }
 
@@ -353,7 +357,7 @@ function deactivateAction(actionId) {
   if (a) a.stop();
 
   gameState.actionsActive = gameState.actionsActive.filter(x => x !== actionId);
-  processActiveAndQueuedActions();
+  pendingActionRefresh = true;
 }
 
 
@@ -364,7 +368,7 @@ function fullyDeactivateAction(actionId) {
   if (a) a.stop();
 
   gameState.actionsActive = gameState.actionsActive.filter(x => x !== actionId);
-  processActiveAndQueuedActions();
+  pendingActionRefresh = true;
 }
 
 function processActiveAndQueuedActions() {

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -519,7 +519,10 @@ eventBus.on('tick-fixed', ({ stepMs }) => runGameTick(stepMs));
 // Render cycle
 eventBus.on('heartbeat', () => {
   Object.values(actionsConstructed).forEach(action => action.render());
-  processActiveAndQueuedActions();
+  if (pendingActionRefresh) {
+    processActiveAndQueuedActions();
+    pendingActionRefresh = false;
+  }
 });
 
 function buttonPause() {
@@ -798,7 +801,7 @@ function initializeGame() {
   });
 
   processPauseButton();
-  processActiveAndQueuedActions();
+  pendingActionRefresh = true;
   if (typeof initLoopTimer === 'function') {
     initLoopTimer(timeMax * 1000);
   }

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -146,14 +146,12 @@ function updateRenderRateDisplay() {
 document.addEventListener('DOMContentLoaded', () => {
   const debugToggle = document.getElementById('debug-toggle');
   if (debugToggle) {
-    debugToggle.addEventListener('change', e => {
-      gameState.debugMode = e.target.checked;
-      if (typeof processActiveAndQueuedActions === 'function') {
-        processActiveAndQueuedActions();
-      }
-      updateDebugToggle();
-    });
-  }
+      debugToggle.addEventListener('change', e => {
+        gameState.debugMode = e.target.checked;
+        pendingActionRefresh = true;
+        updateDebugToggle();
+      });
+    }
   const timeSlider = document.getElementById('time-dilation-slider');
   if (timeSlider) {
     timeSlider.addEventListener('input', e => {

--- a/assets/scripts/ui.js
+++ b/assets/scripts/ui.js
@@ -5,7 +5,7 @@ function showLibrary() {
 
 function showBook() {
   openTab('actions-tab');
-  if (typeof processActiveAndQueuedActions === 'function') { processActiveAndQueuedActions(); }
+  pendingActionRefresh = true;
 }
 
 function showLog() {


### PR DESCRIPTION
## Summary
- Add a `pendingActionRefresh` flag to delay expensive action refreshes
- Flag action-state changes (create/remove/activate/deactivate/complete, availability) instead of refreshing immediately
- Heartbeat now processes queued action refreshes when the flag is set
- Mark debug and UI interactions to use the new flag

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a408e465dc83249705781193e06a5a