### PR TITLE
Refactor clock to tiered refresh events

### DIFF
--- a/assets/scripts/initialize.js
+++ b/assets/scripts/initialize.js
@@ -49,8 +49,7 @@ const emptyGameState = {
     system: { popup: true, log: true }
   },
   globalParameters: {
-    logicHz: 30,        // Gameplay logic ticks per second
-    renderHz: 30,       // UI refresh rate in ticks per second
+    refreshHz: 30,      // Master clock refresh rate in ticks per second
     timeDilation: 1.0,  // Scales all gameplay time
     masteryMaxRatio: 0.9,
     masteryGrowthRate: 5e-6,

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -513,16 +513,16 @@ function runGameTick(stepMs) {
   }
 }
 
-// Listen for each fixed clock beat
-eventBus.on('tick-fixed-critical', ({ gameDelta }) => runGameTick(gameDelta));
+// Listen for each fixed game tick
+eventBus.on('gameTick-fixed-critical', ({ gameDelta }) => runGameTick(gameDelta));
 
-// Core game logic each variable tick
-eventBus.on('tick-critical', () => {
+// Core game logic each variable game tick
+eventBus.on('gameTick-critical', () => {
   processActiveAndQueuedActions();
 });
 
 // Medium-frequency UI updates
-eventBus.on('heartbeat-high', () => {
+eventBus.on('clockTick-high', () => {
   Object.values(actionsConstructed).forEach(action => {
     if (action.needsRender === true) {
       action.render();
@@ -531,12 +531,12 @@ eventBus.on('heartbeat-high', () => {
   });
 });
 
-eventBus.on('tick-high', () => {
+eventBus.on('gameTick-high', () => {
   updateTimerUI();
 });
 
 // Low-frequency refreshers
-eventBus.on('tick-low', () => {
+eventBus.on('gameTick-low', () => {
   checkTimeWarnings();
 });
 

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -513,8 +513,8 @@ function runGameTick(stepMs) {
   }
 }
 
-// Listen for each fixed game tick
-eventBus.on('gameTick-fixed-critical', ({ gameDelta }) => runGameTick(gameDelta));
+// Listen for each fixed tick
+eventBus.on('tick-fixed-critical', ({ gameDelta }) => runGameTick(gameDelta));
 
 // Core game logic each variable game tick
 eventBus.on('gameTick-critical', () => {

--- a/assets/scripts/start.js
+++ b/assets/scripts/start.js
@@ -15,10 +15,10 @@ function updateDebugToggle() {
   if (debugToggle) {
     debugToggle.checked = gameState.debugMode;
   }
-  const renderSlider = document.getElementById('render-rate-slider');
-  if (renderSlider) {
-    renderSlider.value = gameState?.globalParameters?.renderHz ?? 30;
-    updateRenderRateDisplay();
+  const refreshSlider = document.getElementById('refresh-rate-slider');
+  if (refreshSlider) {
+    refreshSlider.value = gameState?.globalParameters?.refreshHz ?? 30;
+    updateRefreshRateDisplay();
   }
   const controls = document.getElementById('time-dilation-controls');
   if (controls) {
@@ -135,9 +135,9 @@ function updateTimeDilationDisplay() {
   }
 }
 
-function updateRenderRateDisplay() {
-  const slider = document.getElementById('render-rate-slider');
-  const disp = document.getElementById('render-rate-display');
+function updateRefreshRateDisplay() {
+  const slider = document.getElementById('refresh-rate-slider');
+  const disp = document.getElementById('refresh-rate-display');
   if (slider && disp) {
     disp.textContent = Number(slider.value);
   }
@@ -163,17 +163,17 @@ document.addEventListener('DOMContentLoaded', () => {
       updateTimeDilationDisplay();
     });
   }
-  const renderSlider = document.getElementById('render-rate-slider');
-  if (renderSlider) {
-    renderSlider.addEventListener('input', e => {
+  const refreshSlider = document.getElementById('refresh-rate-slider');
+  if (refreshSlider) {
+    refreshSlider.addEventListener('input', e => {
       const hz = Number(e.target.value);
-      if (window.gameClock && typeof gameClock.setRenderHz === 'function') {
-        gameClock.setRenderHz(hz);
+      if (window.gameClock && typeof gameClock.setRefreshHz === 'function') {
+        gameClock.setRefreshHz(hz);
       } else {
         if (!gameState.globalParameters) gameState.globalParameters = {};
-        gameState.globalParameters.renderHz = hz;
+        gameState.globalParameters.refreshHz = hz;
       }
-      updateRenderRateDisplay();
+      updateRefreshRateDisplay();
     });
   }
   const resetButton = document.getElementById('reset-game-button');

--- a/index.html
+++ b/index.html
@@ -51,8 +51,8 @@
 					<!-- Settings. Off by default. -->
 					<div id="settings-pane" class="d-none overflow-scroll h-100 col-12">
 						<div class="mb-3">
-							<label for="render-rate-slider" class="form-label">Refresh Rate: <span id="render-rate-display">30</span> Hz</label>
-							<input type="range" class="form-range" id="render-rate-slider" min="5" max="60" step="5" value="30">
+                                                        <label for="refresh-rate-slider" class="form-label">Refresh Rate: <span id="refresh-rate-display">30</span> Hz</label>
+                                                        <input type="range" class="form-range" id="refresh-rate-slider" min="5" max="60" step="5" value="30">
 						</div>
 						<div class="mb-3">
 							<button id="reset-game-button" class="btn btn-danger">Reset Game</button>


### PR DESCRIPTION
## Summary
- unify render and logic rates into a single refresh rate
- emit tiered heartbeat/tick events and update listeners
- expose refresh rate control in settings

## Testing
- `npm test` *(fails: package.json missing)*
- `node --check assets/scripts/clock.js`
- `node --check assets/scripts/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a40f1aeaf48324a340840775f109d0