### PR TITLE
Use CSS transitions for action progress

### DIFF
--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -99,7 +99,11 @@ class GameAction {
                   if (this.isActive) this.calculateTimeMultiplier();
                 };
                 eventBus.on('skills-change', this.skillChangeHandler);
-                if (gameState.debugMode) console.log(`Action ${this.id} started`);
+                const coreMs = this.data.length - this.progress.timeStart;
+                const rate = this.timeMultiplier || 1;
+                const elapsed = (this.progress.timeCurrent - this.progress.timeStart) / rate;
+                ProgressAnimationManager.start(this.id, this.elements.progressBarCurrent, coreMs, rate, elapsed, isGamePaused() ? "paused" : "running");
+    if (gameState.debugMode) console.log(`Action ${this.id} started`);
                 return true;
         }
 
@@ -109,6 +113,7 @@ class GameAction {
                   this.skillChangeHandler = null;
                 }
                 if (gameState.debugMode) console.log(`Action ${this.id} stopped`);
+                ProgressAnimationManager.pause(this.id);
         }
 
   calculateTimeMultiplier() {
@@ -155,8 +160,6 @@ class GameAction {
     const masteryPercentage = (this.progress.timeStart / this.data.length) * 100;
     const label =
       masteryPercentage.toFixed(1) + '% Mastery + ' + (currentPercentage - masteryPercentage).toFixed(1) + '% Current';
-
-    this.elements.progressBarCurrent.style.width = currentPercentage + '%';
     this.elements.progressText.innerText = label;
     this.elements.progressBarMastery.style.width = masteryPercentage + '%';
   }
@@ -164,6 +167,7 @@ class GameAction {
   finish() {
     this.progress.completions += 1;
     if (gameState.debugMode) console.log(`Action ${this.id} finished`);
+    ProgressAnimationManager.complete(this.id);
     this.calculateTimeStart();
     this.progress.timeCurrent = this.progress.timeStart;
     deactivateAction(this.id);
@@ -258,10 +262,21 @@ function createNewAction(id) {
     container.style.display = 'none';
   }
 
-  actionsConstructed[id] = new GameAction(id);
-  updateActionSkillIcons();
-  processActiveAndQueuedActions();
-}
+    actionsConstructed[id] = new GameAction(id);
+    const barEl = actionsConstructed[id].elements.progressBarCurrent;
+    const snap = gameState.progressAnimations?.[id];
+    if (snap) {
+      ProgressAnimationManager.restore(id, barEl, snap);
+    } else {
+      const a = actionsConstructed[id];
+      const coreMs = a.data.length - a.progress.timeStart;
+      const rate = a.timeMultiplier || 1;
+      const elapsed = (a.progress.timeCurrent - a.progress.timeStart) / rate;
+      ProgressAnimationManager.start(id, barEl, coreMs, rate, elapsed, 'paused');
+    }
+    updateActionSkillIcons();
+    processActiveAndQueuedActions();
+  }
 
 // Access a constructed GameAction safely
 function getAction(id) {
@@ -366,7 +381,10 @@ function deactivateAction(actionId) {
 
 function fullyDeactivateAction(actionId) {
   const a = getAction(actionId);
-  if (a) a.stop();
+  if (a) {
+    a.stop();
+    ProgressAnimationManager.reset(actionId);
+  }
 
   gameState.actionsActive = gameState.actionsActive.filter(x => x !== actionId);
   processActiveAndQueuedActions();

--- a/assets/scripts/action_functions.js
+++ b/assets/scripts/action_functions.js
@@ -102,7 +102,16 @@ class GameAction {
                 const coreMs = this.data.length - this.progress.timeStart;
                 const rate = this.timeMultiplier || 1;
                 const elapsed = (this.progress.timeCurrent - this.progress.timeStart) / rate;
-                ProgressAnimationManager.start(this.id, this.elements.progressBarCurrent, coreMs, rate, elapsed, isGamePaused() ? "paused" : "running");
+                const paused = isGamePaused();
+                ProgressAnimationManager.start(
+                  this.id,
+                  this.elements.progressBarCurrent,
+                  coreMs,
+                  rate,
+                  elapsed,
+                  paused ? "paused" : "running",
+                  paused
+                );
     if (gameState.debugMode) console.log(`Action ${this.id} started`);
                 return true;
         }

--- a/assets/scripts/action_runner.js
+++ b/assets/scripts/action_runner.js
@@ -1,5 +1,3 @@
-const USE_SCALEX_ANIMATION = false;
-
 const ProgressAnimationManager = (() => {
   const animations = new Map();
   const prefersReduced =
@@ -9,12 +7,7 @@ const ProgressAnimationManager = (() => {
 
   function setPercent(el, percent) {
     if (!el) return;
-    if (USE_SCALEX_ANIMATION) {
-      el.style.transformOrigin = 'left center';
-      el.style.transform = `scaleX(${percent / 100})`;
-    } else {
-      el.style.width = `${percent}%`;
-    }
+    el.style.width = `${percent}%`;
   }
 
   function snap(el, percent) {
@@ -37,9 +30,8 @@ const ProgressAnimationManager = (() => {
     anim.startedAt = performance.now();
     anim.status = 'running';
     const dur = prefersReduced ? 1 : remaining;
-    const prop = USE_SCALEX_ANIMATION ? 'transform' : 'width';
     rAF(() => {
-      anim.el.style.transition = `${prop} ${dur}ms linear`;
+      anim.el.style.transition = `width ${dur}ms linear`;
       rAF(() => setPercent(anim.el, 100));
     });
   }

--- a/assets/scripts/action_runner.js
+++ b/assets/scripts/action_runner.js
@@ -44,7 +44,15 @@ const ProgressAnimationManager = (() => {
     });
   }
 
-  function start(id, el, coreMs, rateBonus, initialElapsedMs = 0, initialStatus = 'running') {
+  function start(
+    id,
+    el,
+    coreMs,
+    rateBonus,
+    initialElapsedMs = 0,
+    initialStatus = 'running',
+    resumeOnUnpause = false
+  ) {
     const totalMs = coreMs / rateBonus;
     const anim = {
       id,
@@ -53,7 +61,7 @@ const ProgressAnimationManager = (() => {
       elapsedMs: Math.min(initialElapsedMs, totalMs),
       status: initialStatus,
       startedAt: null,
-      resumeOnUnpause: false,
+      resumeOnUnpause,
     };
     animations.set(id, anim);
 
@@ -62,6 +70,8 @@ const ProgressAnimationManager = (() => {
 
     if (initialStatus === 'running' && anim.elapsedMs < totalMs) {
       play(anim);
+    } else if (initialStatus === 'paused' && resumeOnUnpause) {
+      anim.resumeOnUnpause = true;
     }
   }
 
@@ -123,7 +133,7 @@ const ProgressAnimationManager = (() => {
     return out;
   }
 
-  function restore(id, el, snapObj) {
+  function restore(id, el, snapObj, resumeOnUnpause = false) {
     const anim = {
       id,
       el,
@@ -131,14 +141,18 @@ const ProgressAnimationManager = (() => {
       elapsedMs: Math.min(snapObj.elapsedMs, snapObj.totalMs),
       status: snapObj.status,
       startedAt: null,
-      resumeOnUnpause: false,
+      resumeOnUnpause,
     };
     animations.set(id, anim);
     const pct = (anim.elapsedMs / anim.totalMs) * 100;
     snap(el, pct);
 
     if (anim.status === 'running' && anim.elapsedMs < anim.totalMs) {
-      play(anim);
+      if (resumeOnUnpause) {
+        anim.resumeOnUnpause = true;
+      } else {
+        play(anim);
+      }
     }
   }
 

--- a/assets/scripts/action_runner.js
+++ b/assets/scripts/action_runner.js
@@ -1,3 +1,164 @@
+const USE_SCALEX_ANIMATION = false;
+
+const ProgressAnimationManager = (() => {
+  const animations = new Map();
+  const prefersReduced =
+    typeof window !== 'undefined' &&
+    window.matchMedia &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  function setPercent(el, percent) {
+    if (!el) return;
+    if (USE_SCALEX_ANIMATION) {
+      el.style.transformOrigin = 'left center';
+      el.style.transform = `scaleX(${percent / 100})`;
+    } else {
+      el.style.width = `${percent}%`;
+    }
+  }
+
+  function snap(el, percent) {
+    if (!el) return;
+    el.style.transition = 'none';
+    setPercent(el, percent);
+    // Force reflow to apply the width immediately
+    void el.offsetWidth;
+  }
+
+  function start(id, el, coreMs, rateBonus, initialElapsedMs = 0, initialStatus = 'running') {
+    const totalMs = coreMs / rateBonus;
+    const anim = {
+      el,
+      totalMs,
+      elapsedMs: Math.min(initialElapsedMs, totalMs),
+      status: initialStatus,
+      startedAt: null,
+    };
+    animations.set(id, anim);
+
+    const pct = (anim.elapsedMs / totalMs) * 100;
+    snap(el, pct);
+
+    if (initialStatus === 'running' && anim.elapsedMs < totalMs) {
+      anim.startedAt = performance.now();
+      const remaining = totalMs - anim.elapsedMs;
+      const dur = prefersReduced ? 1 : remaining;
+      const prop = USE_SCALEX_ANIMATION ? 'transform' : 'width';
+      el.style.transition = `${prop} ${dur}ms linear`;
+      setPercent(el, 100);
+    }
+  }
+
+  function pause(id) {
+    const anim = animations.get(id);
+    if (!anim || anim.status !== 'running') return;
+    anim.elapsedMs = Math.min(
+      anim.totalMs,
+      anim.elapsedMs + (performance.now() - anim.startedAt)
+    );
+    anim.status = 'paused';
+    const pct = (anim.elapsedMs / anim.totalMs) * 100;
+    snap(anim.el, pct);
+  }
+
+  function resume(id) {
+    const anim = animations.get(id);
+    if (!anim || anim.status !== 'paused') return;
+    const remaining = anim.totalMs - anim.elapsedMs;
+    if (remaining <= 0) {
+      complete(id);
+      return;
+    }
+    anim.startedAt = performance.now();
+    anim.status = 'running';
+    const dur = prefersReduced ? 1 : remaining;
+    const prop = USE_SCALEX_ANIMATION ? 'transform' : 'width';
+    anim.el.style.transition = `${prop} ${dur}ms linear`;
+    setPercent(anim.el, 100);
+  }
+
+  function complete(id) {
+    const anim = animations.get(id);
+    if (!anim) return;
+    anim.elapsedMs = anim.totalMs;
+    anim.status = 'completed';
+    snap(anim.el, 100);
+  }
+
+  function reset(id) {
+    const anim = animations.get(id);
+    if (!anim) return;
+    animations.delete(id);
+    snap(anim.el, 0);
+  }
+
+  function snapshot(id) {
+    const anim = animations.get(id);
+    if (!anim) return null;
+    let elapsed = anim.elapsedMs;
+    if (anim.status === 'running') {
+      elapsed = Math.min(anim.totalMs, elapsed + (performance.now() - anim.startedAt));
+    }
+    return {
+      totalMs: anim.totalMs,
+      elapsedMs: elapsed,
+      status: anim.status,
+    };
+  }
+
+  function snapshotAll() {
+    const out = {};
+    animations.forEach((_, id) => {
+      const snapObj = snapshot(id);
+      if (snapObj) out[id] = snapObj;
+    });
+    return out;
+  }
+
+  function restore(id, el, snapObj) {
+    const anim = {
+      el,
+      totalMs: snapObj.totalMs,
+      elapsedMs: Math.min(snapObj.elapsedMs, snapObj.totalMs),
+      status: snapObj.status,
+      startedAt: null,
+    };
+    animations.set(id, anim);
+    const pct = (anim.elapsedMs / anim.totalMs) * 100;
+    snap(el, pct);
+
+    if (anim.status === 'running' && anim.elapsedMs < anim.totalMs) {
+      const remaining = anim.totalMs - anim.elapsedMs;
+      anim.startedAt = performance.now();
+      const dur = prefersReduced ? 1 : remaining;
+      const prop = USE_SCALEX_ANIMATION ? 'transform' : 'width';
+      el.style.transition = `${prop} ${dur}ms linear`;
+      setPercent(el, 100);
+    }
+  }
+
+  function pauseAll() {
+    animations.forEach((_, id) => pause(id));
+  }
+
+  function resumeAll() {
+    animations.forEach((_, id) => resume(id));
+  }
+
+  return {
+    start,
+    pause,
+    resume,
+    complete,
+    reset,
+    snapshot,
+    snapshotAll,
+    restore,
+    pauseAll,
+    resumeAll,
+  };
+})();
+
 function runActionTick(actionObj, timeChange) {
   const multiplier = actionObj.timeMultiplier ?? 1;
   const newTimeChange = timeChange * multiplier;
@@ -16,4 +177,5 @@ function runActionTick(actionObj, timeChange) {
 
 if (typeof globalThis !== 'undefined') {
   globalThis.runActionTick = runActionTick;
+  globalThis.ProgressAnimationManager = ProgressAnimationManager;
 }

--- a/assets/scripts/action_runner.js
+++ b/assets/scripts/action_runner.js
@@ -33,6 +33,7 @@ const ProgressAnimationManager = (() => {
       elapsedMs: Math.min(initialElapsedMs, totalMs),
       status: initialStatus,
       startedAt: null,
+      resumeOnUnpause: false,
     };
     animations.set(id, anim);
 
@@ -57,6 +58,7 @@ const ProgressAnimationManager = (() => {
       anim.elapsedMs + (performance.now() - anim.startedAt)
     );
     anim.status = 'paused';
+    anim.resumeOnUnpause = false;
     const pct = (anim.elapsedMs / anim.totalMs) * 100;
     snap(anim.el, pct);
   }
@@ -122,6 +124,7 @@ const ProgressAnimationManager = (() => {
       elapsedMs: Math.min(snapObj.elapsedMs, snapObj.totalMs),
       status: snapObj.status,
       startedAt: null,
+      resumeOnUnpause: false,
     };
     animations.set(id, anim);
     const pct = (anim.elapsedMs / anim.totalMs) * 100;
@@ -138,11 +141,21 @@ const ProgressAnimationManager = (() => {
   }
 
   function pauseAll() {
-    animations.forEach((_, id) => pause(id));
+    animations.forEach((anim, id) => {
+      if (anim.status === 'running') {
+        pause(id);
+        anim.resumeOnUnpause = true;
+      }
+    });
   }
 
   function resumeAll() {
-    animations.forEach((_, id) => resume(id));
+    animations.forEach((anim, id) => {
+      if (anim.resumeOnUnpause && anim.status === 'paused') {
+        resume(id);
+      }
+      anim.resumeOnUnpause = false;
+    });
   }
 
   return {

--- a/assets/scripts/initialize.js
+++ b/assets/scripts/initialize.js
@@ -22,6 +22,7 @@ const emptyGameState = {
   actionsAvailable: [],
   actionsActive: [],
   actionsProgress: {},
+  progressAnimations: {},
   // Countdown timer replaces health mechanic
   timeRemaining: defaultLoopTime,
   timeMax: defaultLoopTime,

--- a/assets/scripts/pause_helpers.js
+++ b/assets/scripts/pause_helpers.js
@@ -5,6 +5,10 @@ function addPauseState(state) {
   }
   if (!wasPaused && isGamePaused()) {
     ProgressAnimationManager.pauseAll();
+    gameState.actionsActive.forEach(id => {
+      const a = actionsConstructed[id];
+      if (a) a.syncProgress();
+    });
   }
   processPauseButton();
 }

--- a/assets/scripts/pause_helpers.js
+++ b/assets/scripts/pause_helpers.js
@@ -1,15 +1,23 @@
 function addPauseState(state) {
+  const wasPaused = isGamePaused();
   if (!gameState.pausedReasons.includes(state)) {
     gameState.pausedReasons.unshift(state);
+  }
+  if (!wasPaused && isGamePaused()) {
+    ProgressAnimationManager.pauseAll();
   }
   processPauseButton();
 }
 
 function deletePauseState(state) {
+  const wasPaused = isGamePaused();
   if (state === undefined) {
     gameState.pausedReasons = [];
   } else {
     gameState.pausedReasons = gameState.pausedReasons.filter(reason => reason !== state);
+  }
+  if (wasPaused && !isGamePaused()) {
+    ProgressAnimationManager.resumeAll();
   }
   processPauseButton();
 }

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -760,6 +760,10 @@ function resetGameState() {
 
 async function saveGame(isManualSave = false) {
   try {
+    gameState.actionsActive.forEach(id => {
+      const a = actionsConstructed[id];
+      if (a) a.syncProgress();
+    });
     gameState.progressAnimations = ProgressAnimationManager.snapshotAll();
     await localforage.setItem('gameState', gameState);
     if (isManualSave) { logPopupCombo('Game Saved', 'system'); }

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -760,6 +760,7 @@ function resetGameState() {
 
 async function saveGame(isManualSave = false) {
   try {
+    gameState.progressAnimations = ProgressAnimationManager.snapshotAll();
     await localforage.setItem('gameState', gameState);
     if (isManualSave) { logPopupCombo('Game Saved', 'system'); }
   } catch (error) {
@@ -814,6 +815,17 @@ function initializeGame() {
 
   gameState.actionsAvailable.forEach(actionId => {
     createNewAction(actionId);
+  });
+
+  gameState.actionsActive.forEach(id => {
+    const a = getAction(id);
+    if (a) {
+      a.start();
+      const snap = gameState.progressAnimations?.[id];
+      if (snap) {
+        ProgressAnimationManager.restore(id, a.elements.progressBarCurrent, snap);
+      }
+    }
   });
 
   processPauseButton();

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -823,7 +823,12 @@ function initializeGame() {
       a.start();
       const snap = gameState.progressAnimations?.[id];
       if (snap) {
-        ProgressAnimationManager.restore(id, a.elements.progressBarCurrent, snap);
+        ProgressAnimationManager.restore(
+          id,
+          a.elements.progressBarCurrent,
+          snap,
+          isGamePaused()
+        );
       }
     }
   });

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -314,9 +314,7 @@ body {
         }
 
         .progress-bar {
-          transition-property: width !important;
-          transition-duration: var(--progress-tick-ms) !important;
-          transition-timing-function: linear !important;
+          transition: none;
         }
 
         .action-progress-bar-current, .action-progress-bar-mastery {


### PR DESCRIPTION
## Summary
- implement ProgressAnimationManager for action progress animations
- pause/resume and snapshot progress on global game events and save/load
- track animation state in save data

## Testing
- `npm test` *(fails: no package.json)*
- `node --check assets/scripts/action_runner.js && node --check assets/scripts/action_functions.js && node --check assets/scripts/initialize.js && node --check assets/scripts/pause_helpers.js && node --check assets/scripts/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a56d59b3f88324ae90542d502d219e